### PR TITLE
feat: add zbmath lookup

### DIFF
--- a/bibtexautocomplete/APIs/zbmath.py
+++ b/bibtexautocomplete/APIs/zbmath.py
@@ -1,0 +1,90 @@
+"""
+Lookup info from https://zbmath.org
+"""
+
+from typing import Dict, Iterable, List, Optional
+
+from ..bibtex.author import Author
+from ..bibtex.constants import FieldNames
+from ..bibtex.entry import BibtexEntry
+from ..lookups.lookups import JSON_Lookup
+from ..utils.constants import QUERY_MAX_RESULTS
+from ..utils.safe_json import SafeJSON
+
+
+class ZbMathLookup(JSON_Lookup):
+    """Lookup for info on https://zbmath.org
+    Uses the zbMATH Open API documented here:
+    https://api.zbmath.org/
+
+    example URLs:
+    DOI mode:
+    https://api.zbmath.org/v1/document/_search?search_string=doi:10.1007/3-540-46425-5_21&format=json
+    Title + author:
+    https://api.zbmath.org/v1/document/_search?search_string=Lamiraux&format=json
+    """
+
+    name = "zbmath"
+
+    # ============= Performing Queries =====================
+
+    domain = "api.zbmath.org"
+    path = "/v1/document/_search"
+
+    # zbMATH requires agreement to their terms via a cookie
+    headers = {"Cookie": "tsnc=agreed"}
+
+    def get_params(self) -> Dict[str, str]:
+        params: Dict[str, str] = {"format": "json", "results_per_page": str(QUERY_MAX_RESULTS)}
+        if self.doi is not None:
+            params["search_string"] = f"doi:{self.doi}"
+            return params
+        if self.title is None:
+            raise ValueError("zbMATH called with no title")
+        search = self.title
+        if self.authors:
+            search += " " + " ".join(self.authors)
+        params["search_string"] = search
+        return params
+
+    # ============= Parsing results into entries =====================
+
+    def get_results(self, data: bytes) -> Optional[Iterable[SafeJSON]]:
+        """Return the result list"""
+        json = SafeJSON.from_bytes(data)
+        return json["result"].iter_list()
+
+    @staticmethod
+    def get_authors(authors: SafeJSON) -> List[Author]:
+        """Return a bibtex formatted list of authors"""
+        formatted: List[Author] = []
+        for author in authors.iter_list():
+            name = author["name"].to_str()
+            if name is None:
+                continue
+            aut = Author.from_name(name)
+            if aut is not None:
+                formatted.append(aut)
+        return formatted
+
+    def get_value(self, result: SafeJSON) -> BibtexEntry:
+        """Extract bibtex data from JSON output"""
+        values = BibtexEntry(self.name, self.entry.id)
+        values.author.set(self.get_authors(result["contributors"]["authors"]))
+        values.doi.set(result["doi"].to_str())
+        values.pages.set_str(result["source"]["pages"].to_str())
+        values.title.set(result["title"]["title"].to_str())
+        values.url.set(result["zbmath_url"].to_str())
+        values.year.set(result["year"].to_str())
+        return values
+
+    # Set of fields we can get from a query.
+    # If all are already present on an entry, the query can be skipped.
+    fields = {
+        FieldNames.AUTHOR,
+        FieldNames.DOI,
+        FieldNames.PAGES,
+        FieldNames.TITLE,
+        FieldNames.URL,
+        FieldNames.YEAR,
+    }

--- a/bibtexautocomplete/core/apis.py
+++ b/bibtexautocomplete/core/apis.py
@@ -8,6 +8,7 @@ from ..APIs.openalex import OpenAlexLookup
 from ..APIs.researchr import ResearchrLookup
 from ..APIs.semantic_scholar import SemanticScholarLookup
 from ..APIs.unpaywall import UnpaywallLookup
+from ..APIs.zbmath import ZbMathLookup
 from ..lookups.abstract_entry_lookup import LookupType
 
 # List of lookup to use, in the order they will be used
@@ -20,5 +21,6 @@ LOOKUPS: List[LookupType] = [
     DBLPLookup,
     ResearchrLookup,
     InpireHEPLookup,
+    ZbMathLookup,
 ]
 LOOKUP_NAMES = [cls.name for cls in LOOKUPS]

--- a/tests/test_zbmath.py
+++ b/tests/test_zbmath.py
@@ -1,0 +1,11 @@
+from bibtexautocomplete.APIs.zbmath import ZbMathLookup
+from bibtexautocomplete.bibtex.author import Author
+from bibtexautocomplete.utils.safe_json import SafeJSON
+
+
+def test_get_authors() -> None:
+    authors = SafeJSON.from_str('[{"name":"Lamiraux, F."}, {"name":"Laumond, J.-P."}]')
+    assert ZbMathLookup.get_authors(authors) == [
+        Author("Lamiraux", "F."),
+        Author("Laumond", "J.-P."),
+    ]


### PR DESCRIPTION
## Summary
- integrate zbMATH Open API lookup
- register new lookup in lookup registry
- test zbMATH author parsing

## Testing
- `pre-commit run --files bibtexautocomplete/APIs/zbmath.py bibtexautocomplete/core/apis.py tests/test_zbmath.py`
- `PYTHONPATH=. pytest tests/test_zbmath.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c2925fe8388325bcd8504cbd45481e