### PR TITLE
Handle DOI from zbMATH links

### DIFF
--- a/tests/test_zbmath.py
+++ b/tests/test_zbmath.py
@@ -69,6 +69,23 @@ def test_zbmath_lookup(entry: Dict[str, str], expected: str) -> None:
             assert title is not None and expected.lower() in title.lower()
 
 
+def test_zbmath_lookup_Abels2012_doi() -> None:
+    entry = {
+        "title": "Pseudodifferential and singular integral operators",
+        "author": "Abels, H.",
+        "ID": "Abels2012",
+    }
+    bib = BibtexEntry.from_entry("test", entry)
+    lookup = ZbMathLookup(bib)
+    res = lookup.query()
+    if res is None:
+        status = lookup.get_last_query_info().get("response-status")
+        if isinstance(status, int):
+            assert status == 429 or status >= 500
+    else:
+        assert res.doi.to_str() == "10.1515/9783110250312"
+
+
 def test_zbmath_lookup_no_title() -> None:
     entry = {
         "author": "ABLOWITZ, M. J. and FOKAS, A. S. and MUSSLIMANI, Z. H.",


### PR DESCRIPTION
## Summary
- Check zbMATH `links` for DOI when direct `doi` field is missing
- Normalize DOI before assignment
- Test that Abels2012 lookup returns expected DOI

## Testing
- `pytest tests/test_zbmath.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c2c40b0d3c83258cdc8f009d6e25e5