### PR TITLE
Escape ampersands in journal titles and prefer abbreviated journal field

### DIFF
--- a/bibtexautocomplete/APIs/zbmath.py
+++ b/bibtexautocomplete/APIs/zbmath.py
@@ -5,7 +5,7 @@ from typing import Dict, Iterable, Iterator, List, Optional
 from ..bibtex.author import Author
 from ..bibtex.constants import FieldNames
 from ..bibtex.entry import BibtexEntry
-from ..bibtex.normalize import normalize_doi
+from ..bibtex.normalize import author_search_key, normalize_doi
 from ..lookups.lookups import JSON_Lookup
 from ..utils.constants import QUERY_MAX_RESULTS
 from ..utils.safe_json import JSONType, SafeJSON
@@ -40,7 +40,7 @@ class ZbMathLookup(JSON_Lookup):
         self.doi = self.entry.doi.to_str()
         authors = self.entry.author.value
         if authors is not None:
-            self.authors = [author.lastname for author in authors]
+            self.authors = [author_search_key(author) for author in authors]
 
         if self.query_doi and self.doi is not None:
             yield None

--- a/bibtexautocomplete/bibtex/entry.py
+++ b/bibtexautocomplete/bibtex/entry.py
@@ -238,6 +238,8 @@ class BibtexEntry:
         # can compensate for partial title mismatches
         author_match = self.get_field("author").matches(other.get_field("author"))
         if author_match is not None:
+            if author_match <= FIELD_NO_MATCH:
+                return ENTRY_NO_MATCH
             total += FIELD_MULTIPLIERS["author"][0] * author_match
         # If neither title, DOI nor author match, we can't id the entry with any certainty
         if total <= ENTRY_NO_MATCH:

--- a/bibtexautocomplete/core/autocomplete.py
+++ b/bibtexautocomplete/core/autocomplete.py
@@ -38,7 +38,11 @@ from ..bibtex.base_field import BibtexField
 from ..bibtex.constants import FIELD_NO_MATCH, FieldType, SearchedFields
 from ..bibtex.entry import ENTRY_TYPES, BibtexEntry
 from ..bibtex.io import file_read, file_write, get_entries, make_writer, read, write
-from ..bibtex.normalize import has_field
+from ..bibtex.normalize import (
+    escape_latex_special_chars,
+    has_field,
+    prefer_journal_over_fjournal,
+)
 from ..lookups.abstract_entry_lookup import LookupType
 from ..lookups.https import HTTPSLookup
 from ..utils.ansi import ANSICodes
@@ -414,6 +418,8 @@ class BibtexAutocomplete(Iterable[EntryType]):
             if self.escape_unicode:
                 value = string_to_latex(value)
                 assert isinstance(value, str)
+            else:
+                value = escape_latex_special_chars(value)
             new_entry[self.prefix + field] = value
             changes.append(Changes(field, value, bib_field.source))
 
@@ -438,6 +444,7 @@ class BibtexAutocomplete(Iterable[EntryType]):
                 new_entry = dict()
             entry.clear()
         entry.update(new_entry)
+        prefer_journal_over_fjournal(entry)
 
     def combine_field(
         self, results: List[BibtexEntry], fieldname: FieldType, entry_name: str

--- a/bibtexautocomplete/lookups/multiple_mixin.py
+++ b/bibtexautocomplete/lookups/multiple_mixin.py
@@ -6,7 +6,7 @@ Set class attribute to be used by the query in get_data
 from typing import Iterator, List, Optional
 
 from ..bibtex.entry import BibtexEntry
-from ..bibtex.normalize import normalize_str
+from ..bibtex.normalize import author_search_key, normalize_str
 from .abstract_base import AbstractLookup, Input, Output
 from .abstract_entry_lookup import AbstractEntryLookup
 
@@ -63,7 +63,7 @@ class DAT_Query_Mixin(MultipleQueryMixin[BibtexEntry, BibtexEntry], AbstractEntr
         self.doi = self.entry.doi.to_str()
         authors = self.entry.author.value
         if authors is not None:
-            self.authors = [author.lastname for author in authors]
+            self.authors = [author_search_key(author) for author in authors]
 
         if self.query_doi and self.doi is not None:
             yield None

--- a/tests/test_2_bibtex.py
+++ b/tests/test_2_bibtex.py
@@ -30,6 +30,8 @@ from bibtexautocomplete.bibtex.normalize import (
     normalize_str,
     normalize_str_weak,
     normalize_url,
+    escape_latex_special_chars,
+    prefer_journal_over_fjournal,
 )
 
 tests = [
@@ -60,6 +62,19 @@ tests = [
 @pytest.mark.parametrize(("inp", "out"), tests)
 def test_normalize_str(inp: str, out: str) -> None:
     assert normalize_str(inp) == out
+
+
+def test_escape_latex_special_chars() -> None:
+    assert escape_latex_special_chars("A & B") == "A \\& B"
+
+
+def test_prefer_journal_over_fjournal() -> None:
+    entry = {"journal": "Abbrev", "fjournal": "Full"}
+    prefer_journal_over_fjournal(entry)
+    assert entry == {"journal": "Abbrev"}
+    entry = {"fjournal": "Full"}
+    prefer_journal_over_fjournal(entry)
+    assert entry == {"journal": "Full"}
 
 
 def test_normalize_doi() -> None:

--- a/tests/test_3_lookup.py
+++ b/tests/test_3_lookup.py
@@ -48,25 +48,27 @@ class TestDATQuery:
 
     def test_all(self) -> None:
         title = "This is a title++"
-        authors = ["Alp", "Rom", "Bob"]
+        authors = ["Alice Alp", "Romeo Rom", "Bob Bob"]
+        search_authors = ["Alp, A*", "Rom, R*", "Bob, B*"]
         doi = "10.1234/123456"
         entry = {"doi": doi, "author": " and ".join(authors), "title": title}
         expected: List[ToCheck] = [
-            ToCheck(doi=doi, author=authors, title=title),
-            ToCheck(doi=None, author=authors, title=title),
+            ToCheck(doi=doi, author=search_authors, title=title),
+            ToCheck(doi=None, author=search_authors, title=title),
             ToCheck(doi=None, author=None, title=title),
         ]
         self.make_query(expected, entry)
 
     def test_no_doi(self) -> None:
         title = "this is a title"
-        authors = ["Alp", "Rom", "Bob"]
+        authors = ["Alice Alp", "Romeo Rom", "Bob Bob"]
+        search_authors = ["Alp, A*", "Rom, R*", "Bob, B*"]
         entry = {
             "author": " and ".join(authors),
             "title": title,
         }
         expected: List[ToCheck] = [
-            ToCheck(doi=None, author=authors, title=title),
+            ToCheck(doi=None, author=search_authors, title=title),
             ToCheck(doi=None, author=None, title=title),
         ]
         self.make_query(expected, entry)
@@ -85,14 +87,15 @@ class TestDATQuery:
         self.make_query(expected, entry)
 
     def test_no_title(self) -> None:
-        authors = ["Alp", "Rom", "Bob"]
+        authors = ["Alice Alp", "Romeo Rom", "Bob Bob"]
+        search_authors = ["Alp, A*", "Rom, R*", "Bob, B*"]
         doi = "10.1234/123456"
         entry = {
             "doi": doi,
             "author": " and ".join(authors),
         }
         expected: List[ToCheck] = [
-            ToCheck(doi=doi, author=authors, title=None),
+            ToCheck(doi=doi, author=search_authors, title=None),
         ]
         self.make_query(expected, entry)
 


### PR DESCRIPTION
## Summary
- escape ampersands when writing BibTeX fields to keep `\&`
- prefer `journal` over `fjournal` entries and drop the latter when both exist
- treat mismatched authors as non-matching in entry comparison
- search authors using "Last, F*" pattern for more precise lookup queries

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c560501f908325a7c6f6dd7ebb2da1