### PR TITLE
Log missing or ambiguous lookup results

### DIFF
--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -1,0 +1,27 @@
+from types import SimpleNamespace
+
+from bibtexautocomplete.bibtex.entry import BibtexEntry
+from bibtexautocomplete.core.autocomplete import BibtexAutocomplete
+
+
+class ThreadStub:
+    def __init__(self, name, result, info):
+        self.lookup = SimpleNamespace(name=name)
+        self.result = [(result, info)]
+
+
+def test_log_not_found(caplog):
+    btac = BibtexAutocomplete(lookups=[], verbose=0)
+    entry = {"ID": "missing"}
+    thread = ThreadStub("stub", None, {"hit-count": 0})
+    btac.update_entry(entry, set(), [thread])
+    assert "No matches found for 'missing'" in caplog.text
+
+
+def test_log_multiple_hits(caplog):
+    btac = BibtexAutocomplete(lookups=[], verbose=0)
+    entry = {"ID": "dup"}
+    res = BibtexEntry("src", "dup")
+    thread = ThreadStub("stublookup", res, {"hit-count": 3})
+    btac.update_entry(entry, set(), [thread])
+    assert "Entry 'dup' matched multiple results: stublookup (3 hits)" in caplog.text


### PR DESCRIPTION
## Summary
- track result counts in search mixin and expose via `hit-count`
- log bib entries that produce no matches or multiple matches
- add tests for the new logging behaviour

## Testing
- `pytest tests/test_logging.py`
- `pytest` *(fails: DOICheck and URLCheck require network access)*

------
https://chatgpt.com/codex/tasks/task_e_68c7fc5e83308325a88a6a62a812c557