### PR TITLE
Add log files for missing and ambiguous entries

### DIFF
--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -10,18 +10,39 @@ class ThreadStub:
         self.result = [(result, info)]
 
 
-def test_log_not_found(caplog):
-    btac = BibtexAutocomplete(lookups=[], verbose=0)
+def test_log_not_found(caplog, tmp_path):
+    not_found_log = tmp_path / "not-found.log"
+    multi_hits_log = tmp_path / "multi-hits.log"
+    btac = BibtexAutocomplete(
+        lookups=[],
+        verbose=0,
+        not_found_log_path=not_found_log,
+        multiple_hits_log_path=multi_hits_log,
+    )
     entry = {"ID": "missing"}
     thread = ThreadStub("stub", None, {"hit-count": 0})
     btac.update_entry(entry, set(), [thread])
     assert "No matches found for 'missing'" in caplog.text
+    assert not_found_log.read_text(encoding="utf-8").strip().splitlines() == ["missing"]
+    assert multi_hits_log.read_text(encoding="utf-8") == ""
 
 
-def test_log_multiple_hits(caplog):
-    btac = BibtexAutocomplete(lookups=[], verbose=0)
+def test_log_multiple_hits(caplog, tmp_path):
+    not_found_log = tmp_path / "not-found.log"
+    multi_hits_log = tmp_path / "multi-hits.log"
+    btac = BibtexAutocomplete(
+        lookups=[],
+        verbose=0,
+        not_found_log_path=not_found_log,
+        multiple_hits_log_path=multi_hits_log,
+    )
     entry = {"ID": "dup"}
     res = BibtexEntry("src", "dup")
     thread = ThreadStub("stublookup", res, {"hit-count": 3})
     btac.update_entry(entry, set(), [thread])
     assert "Entry 'dup' matched multiple results: stublookup (3 hits)" in caplog.text
+    assert not_found_log.read_text(encoding="utf-8") == ""
+    assert (
+        multi_hits_log.read_text(encoding="utf-8").strip().splitlines()
+        == ["dup: stublookup (3 hits)"]
+    )


### PR DESCRIPTION
## Summary
- add optional log file path arguments to `BibtexAutocomplete`
- write unmatched and multi-hit entry information to separate log files
- extend logging tests to validate the new log file contents

## Testing
- PYTHONPATH=. pytest tests/test_logging.py

------
https://chatgpt.com/codex/tasks/task_e_68c925ffdb5c83259ad24ee777073638