### PR TITLE
Avoid creating log files during BibtexAutocomplete initialization

### DIFF
--- a/bibtexautocomplete/core/autocomplete.py
+++ b/bibtexautocomplete/core/autocomplete.py
@@ -173,8 +173,8 @@ class BibtexAutocomplete(Iterable[EntryType]):
         no_trailing_comma: bool = False,
         indent: str = "\t",
         color: Optional[Literal["auto", "always", "never"]] = None,
-        not_found_log_path: Optional[PathType] = Path("btac-not-found.log"),
-        multiple_hits_log_path: Optional[PathType] = Path("btac-multiple-hits.log"),
+        not_found_log_path: Optional[PathType] = None,
+        multiple_hits_log_path: Optional[PathType] = None,
     ):
         # main set the color directly because it can output various warnings,
         # but for API use, we can also set the color here


### PR DESCRIPTION
## Summary
- default the log file path arguments to ``None`` so BibtexAutocomplete no longer creates log files unless explicitly requested

## Testing
- PYTHONPATH=. pytest tests/test_logging.py

------
https://chatgpt.com/codex/tasks/task_e_68c92d11745c8325b983dff1947fa0b0