### PR TITLE
Add source comments to BibTeX output

### DIFF
--- a/tests/bibs/doi-to-url.btac.bib.exp
+++ b/tests/bibs/doi-to-url.btac.bib.exp
@@ -3,6 +3,7 @@
 
 @comment{Outside of entries, text is just a comment}
 
+% BTAC sources: input, fake_lookup
 @misc{entry_basic,
 	title = {My awesome article},
 	author = {Yours Truly},
@@ -18,6 +19,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {1},
 }
 
+% BTAC sources: input, fake_lookup
 @article{entry_basic2,
 	title = {Something},
 	author = {Someone},
@@ -35,14 +37,17 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {2},
 }
 
+% BTAC sources: input
 @booklet{almost_empty,
 	note = {This entry shouldn't be queried, no useful data},
 }
 
+% BTAC sources: input
 @techreport{also_almost_empty,
 	foo = {bar: no standard field at all},
 }
 
+% BTAC sources: input, fake_lookup
 @article{doi,
 	title = {Generated title 5},
 	author = {Doe5, John},
@@ -59,6 +64,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {5},
 }
 
+% BTAC sources: input, fake_lookup
 @inproceedings{giberish,
 	title = {giberish},
 	author = {1789},
@@ -78,6 +84,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {6},
 }
 
+% BTAC sources: input
 @article{full,
 	title = {Full entry, never queried, but field order changed},
 	author = {1789},
@@ -96,6 +103,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {full},
 }
 
+% BTAC sources: input
 @misc{marked,
 	title = {marked entry is not queried},
 	btacqueried = {2024-07-19},
@@ -103,12 +111,14 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	pages = {1--150},
 }
 
+% BTAC sources: input
 @article{markedbis,
 	title = {marked entry is not queried},
 	btacqueried = {not necessarily a data},
 	doi = {10.22222/123456789},
 }
 
+% BTAC sources: input, fake_lookup
 @misc{all_fields_for_misc,
 	title = {Test for filter-by-entrytype},
 	author = {My Guy},
@@ -126,6 +136,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	year = {2015},
 }
 
+% BTAC sources: input, fake_lookup
 @misc{opt_field_for_misc,
 	title = {Test for filter-by-entrytype},
 	author = {My Guy},
@@ -143,6 +154,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	year = {2015},
 }
 
+% BTAC sources: input, fake_lookup
 @misc{req_field_for_misc,
 	title = {Test for filter-by-entrytype},
 	author = {Doe9, John},
@@ -158,6 +170,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {9},
 }
 
+% BTAC sources: input, fake_lookup
 @article{entry0,
 	title = {Title of entry 0},
 	author = {Doe10, John},
@@ -173,6 +186,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {10},
 }
 
+% BTAC sources: input, fake_lookup
 @book{entry1,
 	title = {Title of entry 1},
 	author = {Doe11, John},
@@ -189,6 +203,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {11},
 }
 
+% BTAC sources: input, fake_lookup
 @booklet{entry2,
 	title = {Title of entry 2},
 	author = {Doe12, John},
@@ -204,6 +219,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {12},
 }
 
+% BTAC sources: input, fake_lookup
 @conference{entry3,
 	title = {Title of entry 3},
 	author = {Doe13, John},
@@ -220,6 +236,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {13},
 }
 
+% BTAC sources: input, fake_lookup
 @inbook{entry4,
 	title = {Title of entry 4},
 	author = {Doe14, John},
@@ -236,6 +253,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {14},
 }
 
+% BTAC sources: input, fake_lookup
 @incollection{entry5,
 	title = {Title of entry 5},
 	author = {Doe15, John},
@@ -251,6 +269,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {15},
 }
 
+% BTAC sources: input, fake_lookup
 @manual{entry6,
 	title = {Title of entry 6},
 	author = {Doe16, John},
@@ -266,6 +285,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {16},
 }
 
+% BTAC sources: input, fake_lookup
 @mastersthesis{entry7,
 	title = {Title of entry 7},
 	author = {Doe17, John},
@@ -282,6 +302,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {17},
 }
 
+% BTAC sources: input, fake_lookup
 @misc{entry8,
 	title = {Title of entry 8},
 	author = {Doe18, John},
@@ -297,6 +318,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {18},
 }
 
+% BTAC sources: input, fake_lookup
 @techreport{entry9,
 	title = {Title of entry 9},
 	author = {Doe19, John},
@@ -312,6 +334,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {19},
 }
 
+% BTAC sources: input, fake_lookup
 @unpublished{entry10,
 	title = {Title of entry 10},
 	author = {Doe20, John},
@@ -328,6 +351,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {20},
 }
 
+% BTAC sources: input, fake_lookup
 @inproceedings{entry11,
 	title = {Title of entry 11},
 	author = {Doe21, John},
@@ -343,6 +367,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {21},
 }
 
+% BTAC sources: input, fake_lookup
 @phdthesis{entry12,
 	title = {Title of entry 12},
 	author = {Doe22, John},
@@ -358,6 +383,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {22},
 }
 
+% BTAC sources: input, fake_lookup
 @misc{with_accents,
 	title = {Lots OF accents AnD Capitalization: éàêïæøçÉÀÊÏÆØÇ},
 	author = {Somebody},

--- a/tests/bibs/field-selection-and-entrytype.btac.bib.exp
+++ b/tests/bibs/field-selection-and-entrytype.btac.bib.exp
@@ -3,31 +3,37 @@
 
 @comment{Outside of entries, text is just a comment}
 
+% BTAC sources: input
 @misc{entry_basic,
 	title = {My awesome article},
 	author = {Yours Truly},
 }
 
+% BTAC sources: input, fake_lookup
 @article{entry_basic2,
 	title = {Something},
 	author = {Someone},
 	journal = {Generated Journal 1},
 }
 
+% BTAC sources: input
 @booklet{almost_empty,
 	note = {This entry shouldn't be queried, no useful data},
 }
 
+% BTAC sources: input
 @techreport{also_almost_empty,
 	foo = {bar: no standard field at all},
 }
 
+% BTAC sources: input, fake_lookup
 @article{doi,
 	title = {Generated title 4},
 	doi = {10.5432/hello},
 	journal = {Generated Journal 4},
 }
 
+% BTAC sources: input, fake_lookup
 @inproceedings{giberish,
 	title = {giberish},
 	author = {1789},
@@ -40,6 +46,7 @@
 	pages = {not a number},
 }
 
+% BTAC sources: input
 @article{full,
 	title = {Full entry, never queried, but field order changed},
 	author = {1789},
@@ -58,6 +65,7 @@
 	volume = {full},
 }
 
+% BTAC sources: input
 @misc{marked,
 	title = {marked entry is not queried},
 	btacqueried = {2024-07-19},
@@ -65,12 +73,14 @@
 	pages = {1--150},
 }
 
+% BTAC sources: input
 @article{markedbis,
 	title = {marked entry is not queried},
 	btacqueried = {not necessarily a data},
 	doi = {10.22222/123456789},
 }
 
+% BTAC sources: input
 @misc{all_fields_for_misc,
 	title = {Test for filter-by-entrytype},
 	author = {My Guy},
@@ -81,6 +91,7 @@
 	year = {2015},
 }
 
+% BTAC sources: input
 @misc{opt_field_for_misc,
 	title = {Test for filter-by-entrytype},
 	author = {My Guy},
@@ -90,69 +101,84 @@
 	year = {2015},
 }
 
+% BTAC sources: input
 @misc{req_field_for_misc,
 	title = {Test for filter-by-entrytype},
 }
 
+% BTAC sources: input, fake_lookup
 @article{entry0,
 	title = {Title of entry 0},
 	journal = {Generated Journal 6},
 }
 
+% BTAC sources: input
 @book{entry1,
 	title = {Title of entry 1},
 }
 
+% BTAC sources: input
 @booklet{entry2,
 	title = {Title of entry 2},
 }
 
+% BTAC sources: input, fake_lookup
 @conference{entry3,
 	title = {Title of entry 3},
 	booktitle = {Generated booktitle 7},
 }
 
+% BTAC sources: input, fake_lookup
 @inbook{entry4,
 	title = {Title of entry 4},
 	pages = {1--8},
 }
 
+% BTAC sources: input, fake_lookup
 @incollection{entry5,
 	title = {Title of entry 5},
 	booktitle = {Generated booktitle 9},
 }
 
+% BTAC sources: input
 @manual{entry6,
 	title = {Title of entry 6},
 }
 
+% BTAC sources: input
 @mastersthesis{entry7,
 	title = {Title of entry 7},
 }
 
+% BTAC sources: input
 @misc{entry8,
 	title = {Title of entry 8},
 }
 
+% BTAC sources: input
 @techreport{entry9,
 	title = {Title of entry 9},
 }
 
+% BTAC sources: input, fake_lookup
 @unpublished{entry10,
 	title = {Title of entry 10},
 	note = {Note: this is query number 10
 Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 }
 
+% BTAC sources: input, fake_lookup
 @inproceedings{entry11,
 	title = {Title of entry 11},
 	booktitle = {Generated booktitle 11},
 }
 
+% BTAC sources: input
 @phdthesis{entry12,
 	title = {Title of entry 12},
 }
 
+% BTAC sources: input
 @misc{with_accents,
 	title = {Lots OF accents AnD Capitalization: éàêïæøçÉÀÊÏÆØÇ},
 	author = {Somebody},

--- a/tests/bibs/field-selection-force-prefix.btac.bib.exp
+++ b/tests/bibs/field-selection-force-prefix.btac.bib.exp
@@ -3,6 +3,7 @@
 
 @comment{Outside of entries, text is just a comment}
 
+% BTAC sources: input, fake_lookup
 @misc{entry_basic,
 	title = {My awesome article},
 	author = {Yours Truly},
@@ -19,6 +20,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	BTACvolume = {1},
 }
 
+% BTAC sources: input, fake_lookup
 @article{entry_basic2,
 	title = {Something},
 	author = {Someone},
@@ -36,14 +38,17 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	BTACvolume = {2},
 }
 
+% BTAC sources: input
 @booklet{almost_empty,
 	note = {This entry shouldn't be queried, no useful data},
 }
 
+% BTAC sources: input
 @techreport{also_almost_empty,
 	foo = {bar: no standard field at all},
 }
 
+% BTAC sources: input, fake_lookup
 @article{doi,
 	BTACbooktitle = {Generated booktitle 5},
 	BTACdoi = {10.5432/hello},
@@ -59,6 +64,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	doi = {10.5432/hello},
 }
 
+% BTAC sources: input, fake_lookup
 @inproceedings{giberish,
 	title = {giberish},
 	author = {1789},
@@ -81,6 +87,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	pages = {not a number},
 }
 
+% BTAC sources: input, fake_lookup
 @article{full,
 	title = {Full entry, never queried, but field order changed},
 	author = {1789},
@@ -109,6 +116,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {full},
 }
 
+% BTAC sources: input
 @misc{marked,
 	title = {marked entry is not queried},
 	btacqueried = {2024-07-19},
@@ -116,12 +124,14 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	pages = {1--150},
 }
 
+% BTAC sources: input
 @article{markedbis,
 	title = {marked entry is not queried},
 	btacqueried = {not necessarily a data},
 	doi = {10.22222/123456789},
 }
 
+% BTAC sources: input, fake_lookup
 @misc{all_fields_for_misc,
 	title = {Test for filter-by-entrytype},
 	author = {My Guy},
@@ -142,6 +152,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	year = {2015},
 }
 
+% BTAC sources: input, fake_lookup
 @misc{opt_field_for_misc,
 	title = {Test for filter-by-entrytype},
 	author = {My Guy},
@@ -161,6 +172,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	year = {2015},
 }
 
+% BTAC sources: input, fake_lookup
 @misc{req_field_for_misc,
 	title = {Test for filter-by-entrytype},
 	BTACbooktitle = {Generated booktitle 10},
@@ -176,6 +188,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	BTACvolume = {10},
 }
 
+% BTAC sources: input, fake_lookup
 @article{entry0,
 	title = {Title of entry 0},
 	BTACbooktitle = {Generated booktitle 11},
@@ -191,6 +204,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	BTACvolume = {11},
 }
 
+% BTAC sources: input, fake_lookup
 @book{entry1,
 	title = {Title of entry 1},
 	BTACbooktitle = {Generated booktitle 12},
@@ -206,6 +220,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	BTACvolume = {12},
 }
 
+% BTAC sources: input, fake_lookup
 @booklet{entry2,
 	title = {Title of entry 2},
 	BTACbooktitle = {Generated booktitle 13},
@@ -222,6 +237,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	BTACvolume = {13},
 }
 
+% BTAC sources: input, fake_lookup
 @conference{entry3,
 	title = {Title of entry 3},
 	BTACbooktitle = {Generated booktitle 14},
@@ -237,6 +253,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	BTACvolume = {14},
 }
 
+% BTAC sources: input, fake_lookup
 @inbook{entry4,
 	title = {Title of entry 4},
 	BTACbooktitle = {Generated booktitle 15},
@@ -252,6 +269,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	BTACvolume = {15},
 }
 
+% BTAC sources: input, fake_lookup
 @incollection{entry5,
 	title = {Title of entry 5},
 	BTACbooktitle = {Generated booktitle 16},
@@ -267,6 +285,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	BTACvolume = {16},
 }
 
+% BTAC sources: input, fake_lookup
 @manual{entry6,
 	title = {Title of entry 6},
 	BTACbooktitle = {Generated booktitle 17},
@@ -282,6 +301,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	BTACvolume = {17},
 }
 
+% BTAC sources: input, fake_lookup
 @mastersthesis{entry7,
 	title = {Title of entry 7},
 	BTACbooktitle = {Generated booktitle 18},
@@ -297,6 +317,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	BTACvolume = {18},
 }
 
+% BTAC sources: input, fake_lookup
 @misc{entry8,
 	title = {Title of entry 8},
 	BTACbooktitle = {Generated booktitle 19},
@@ -312,6 +333,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	BTACvolume = {19},
 }
 
+% BTAC sources: input, fake_lookup
 @techreport{entry9,
 	title = {Title of entry 9},
 	BTACbooktitle = {Generated booktitle 20},
@@ -327,6 +349,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	BTACvolume = {20},
 }
 
+% BTAC sources: input, fake_lookup
 @unpublished{entry10,
 	title = {Title of entry 10},
 	BTACbooktitle = {Generated booktitle 21},
@@ -342,6 +365,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	BTACvolume = {21},
 }
 
+% BTAC sources: input, fake_lookup
 @inproceedings{entry11,
 	title = {Title of entry 11},
 	BTACbooktitle = {Generated booktitle 22},
@@ -357,6 +381,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	BTACvolume = {22},
 }
 
+% BTAC sources: input, fake_lookup
 @phdthesis{entry12,
 	title = {Title of entry 12},
 	BTACbooktitle = {Generated booktitle 23},
@@ -372,6 +397,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	BTACvolume = {23},
 }
 
+% BTAC sources: input, fake_lookup
 @misc{with_accents,
 	title = {Lots OF accents AnD Capitalization: éàêïæøçÉÀÊÏÆØÇ},
 	author = {Somebody},

--- a/tests/bibs/field-selection-force.btac.bib.exp
+++ b/tests/bibs/field-selection-force.btac.bib.exp
@@ -3,6 +3,7 @@
 
 @comment{Outside of entries, text is just a comment}
 
+% BTAC sources: input, fake_lookup
 @misc{entry_basic,
 	title = {My awesome article},
 	author = {Yours Truly},
@@ -18,6 +19,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {1},
 }
 
+% BTAC sources: input, fake_lookup
 @article{entry_basic2,
 	title = {Something},
 	author = {Someone},
@@ -34,14 +36,17 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {2},
 }
 
+% BTAC sources: input
 @booklet{almost_empty,
 	note = {This entry shouldn't be queried, no useful data},
 }
 
+% BTAC sources: input
 @techreport{also_almost_empty,
 	foo = {bar: no standard field at all},
 }
 
+% BTAC sources: input, fake_lookup
 @article{doi,
 	title = {Generated title 5},
 	booktitle = {Generated booktitle 5},
@@ -56,6 +61,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {5},
 }
 
+% BTAC sources: input, fake_lookup
 @inproceedings{giberish,
 	title = {giberish},
 	author = {1789},
@@ -75,6 +81,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {6},
 }
 
+% BTAC sources: input, fake_lookup
 @article{full,
 	title = {Full entry, never queried, but field order changed},
 	author = {1789},
@@ -93,6 +100,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {full},
 }
 
+% BTAC sources: input
 @misc{marked,
 	title = {marked entry is not queried},
 	btacqueried = {2024-07-19},
@@ -100,12 +108,14 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	pages = {1--150},
 }
 
+% BTAC sources: input
 @article{markedbis,
 	title = {marked entry is not queried},
 	btacqueried = {not necessarily a data},
 	doi = {10.22222/123456789},
 }
 
+% BTAC sources: input, fake_lookup
 @misc{all_fields_for_misc,
 	title = {Test for filter-by-entrytype},
 	author = {My Guy},
@@ -122,6 +132,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	year = {2015},
 }
 
+% BTAC sources: input, fake_lookup
 @misc{opt_field_for_misc,
 	title = {Test for filter-by-entrytype},
 	author = {My Guy},
@@ -138,6 +149,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	year = {2015},
 }
 
+% BTAC sources: input, fake_lookup
 @misc{req_field_for_misc,
 	title = {Test for filter-by-entrytype},
 	booktitle = {Generated booktitle 10},
@@ -152,6 +164,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {10},
 }
 
+% BTAC sources: input, fake_lookup
 @article{entry0,
 	title = {Title of entry 0},
 	booktitle = {Generated booktitle 11},
@@ -166,6 +179,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {11},
 }
 
+% BTAC sources: input, fake_lookup
 @book{entry1,
 	title = {Title of entry 1},
 	booktitle = {Generated booktitle 12},
@@ -180,6 +194,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {12},
 }
 
+% BTAC sources: input, fake_lookup
 @booklet{entry2,
 	title = {Title of entry 2},
 	booktitle = {Generated booktitle 13},
@@ -195,6 +210,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {13},
 }
 
+% BTAC sources: input, fake_lookup
 @conference{entry3,
 	title = {Title of entry 3},
 	booktitle = {Generated booktitle 14},
@@ -209,6 +225,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {14},
 }
 
+% BTAC sources: input, fake_lookup
 @inbook{entry4,
 	title = {Title of entry 4},
 	booktitle = {Generated booktitle 15},
@@ -223,6 +240,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {15},
 }
 
+% BTAC sources: input, fake_lookup
 @incollection{entry5,
 	title = {Title of entry 5},
 	booktitle = {Generated booktitle 16},
@@ -237,6 +255,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {16},
 }
 
+% BTAC sources: input, fake_lookup
 @manual{entry6,
 	title = {Title of entry 6},
 	booktitle = {Generated booktitle 17},
@@ -251,6 +270,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {17},
 }
 
+% BTAC sources: input, fake_lookup
 @mastersthesis{entry7,
 	title = {Title of entry 7},
 	booktitle = {Generated booktitle 18},
@@ -265,6 +285,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {18},
 }
 
+% BTAC sources: input, fake_lookup
 @misc{entry8,
 	title = {Title of entry 8},
 	booktitle = {Generated booktitle 19},
@@ -279,6 +300,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {19},
 }
 
+% BTAC sources: input, fake_lookup
 @techreport{entry9,
 	title = {Title of entry 9},
 	booktitle = {Generated booktitle 20},
@@ -293,6 +315,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {20},
 }
 
+% BTAC sources: input, fake_lookup
 @unpublished{entry10,
 	title = {Title of entry 10},
 	booktitle = {Generated booktitle 21},
@@ -307,6 +330,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {21},
 }
 
+% BTAC sources: input, fake_lookup
 @inproceedings{entry11,
 	title = {Title of entry 11},
 	booktitle = {Generated booktitle 22},
@@ -321,6 +345,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {22},
 }
 
+% BTAC sources: input, fake_lookup
 @phdthesis{entry12,
 	title = {Title of entry 12},
 	booktitle = {Generated booktitle 23},
@@ -335,6 +360,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {23},
 }
 
+% BTAC sources: input, fake_lookup
 @misc{with_accents,
 	title = {Lots OF accents AnD Capitalization: éàêïæøçÉÀÊÏÆØÇ},
 	author = {Somebody},

--- a/tests/bibs/field-selection-overwrite.btac.bib.exp
+++ b/tests/bibs/field-selection-overwrite.btac.bib.exp
@@ -3,6 +3,7 @@
 
 @comment{Outside of entries, text is just a comment}
 
+% BTAC sources: input, fake_lookup
 @misc{entry_basic,
 	title = {My awesome article},
 	author = {Yours Truly},
@@ -18,6 +19,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {1},
 }
 
+% BTAC sources: input, fake_lookup
 @article{entry_basic2,
 	title = {Something},
 	author = {Someone},
@@ -34,14 +36,17 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {2},
 }
 
+% BTAC sources: input
 @booklet{almost_empty,
 	note = {This entry shouldn't be queried, no useful data},
 }
 
+% BTAC sources: input
 @techreport{also_almost_empty,
 	foo = {bar: no standard field at all},
 }
 
+% BTAC sources: input, fake_lookup
 @article{doi,
 	title = {Generated title 5},
 	booktitle = {Generated booktitle 5},
@@ -56,6 +61,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {5},
 }
 
+% BTAC sources: input, fake_lookup
 @inproceedings{giberish,
 	title = {giberish},
 	author = {1789},
@@ -75,6 +81,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {6},
 }
 
+% BTAC sources: input, fake_lookup
 @article{full,
 	title = {Full entry, never queried, but field order changed},
 	author = {1789},
@@ -93,6 +100,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {full},
 }
 
+% BTAC sources: input
 @misc{marked,
 	title = {marked entry is not queried},
 	btacqueried = {2024-07-19},
@@ -100,12 +108,14 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	pages = {1--150},
 }
 
+% BTAC sources: input
 @article{markedbis,
 	title = {marked entry is not queried},
 	btacqueried = {not necessarily a data},
 	doi = {10.22222/123456789},
 }
 
+% BTAC sources: input, fake_lookup
 @misc{all_fields_for_misc,
 	title = {Test for filter-by-entrytype},
 	author = {My Guy},
@@ -122,6 +132,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	year = {2015},
 }
 
+% BTAC sources: input, fake_lookup
 @misc{opt_field_for_misc,
 	title = {Test for filter-by-entrytype},
 	author = {My Guy},
@@ -138,6 +149,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	year = {2015},
 }
 
+% BTAC sources: input, fake_lookup
 @misc{req_field_for_misc,
 	title = {Test for filter-by-entrytype},
 	booktitle = {Generated booktitle 10},
@@ -152,6 +164,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {10},
 }
 
+% BTAC sources: input, fake_lookup
 @article{entry0,
 	title = {Title of entry 0},
 	booktitle = {Generated booktitle 11},
@@ -166,6 +179,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {11},
 }
 
+% BTAC sources: input, fake_lookup
 @book{entry1,
 	title = {Title of entry 1},
 	booktitle = {Generated booktitle 12},
@@ -180,6 +194,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {12},
 }
 
+% BTAC sources: input, fake_lookup
 @booklet{entry2,
 	title = {Title of entry 2},
 	booktitle = {Generated booktitle 13},
@@ -195,6 +210,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {13},
 }
 
+% BTAC sources: input, fake_lookup
 @conference{entry3,
 	title = {Title of entry 3},
 	booktitle = {Generated booktitle 14},
@@ -209,6 +225,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {14},
 }
 
+% BTAC sources: input, fake_lookup
 @inbook{entry4,
 	title = {Title of entry 4},
 	booktitle = {Generated booktitle 15},
@@ -223,6 +240,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {15},
 }
 
+% BTAC sources: input, fake_lookup
 @incollection{entry5,
 	title = {Title of entry 5},
 	booktitle = {Generated booktitle 16},
@@ -237,6 +255,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {16},
 }
 
+% BTAC sources: input, fake_lookup
 @manual{entry6,
 	title = {Title of entry 6},
 	booktitle = {Generated booktitle 17},
@@ -251,6 +270,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {17},
 }
 
+% BTAC sources: input, fake_lookup
 @mastersthesis{entry7,
 	title = {Title of entry 7},
 	booktitle = {Generated booktitle 18},
@@ -265,6 +285,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {18},
 }
 
+% BTAC sources: input, fake_lookup
 @misc{entry8,
 	title = {Title of entry 8},
 	booktitle = {Generated booktitle 19},
@@ -279,6 +300,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {19},
 }
 
+% BTAC sources: input, fake_lookup
 @techreport{entry9,
 	title = {Title of entry 9},
 	booktitle = {Generated booktitle 20},
@@ -293,6 +315,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {20},
 }
 
+% BTAC sources: input, fake_lookup
 @unpublished{entry10,
 	title = {Title of entry 10},
 	booktitle = {Generated booktitle 21},
@@ -307,6 +330,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {21},
 }
 
+% BTAC sources: input, fake_lookup
 @inproceedings{entry11,
 	title = {Title of entry 11},
 	booktitle = {Generated booktitle 22},
@@ -321,6 +345,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {22},
 }
 
+% BTAC sources: input, fake_lookup
 @phdthesis{entry12,
 	title = {Title of entry 12},
 	booktitle = {Generated booktitle 23},
@@ -335,6 +360,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {23},
 }
 
+% BTAC sources: input, fake_lookup
 @misc{with_accents,
 	title = {Lots OF accents AnD Capitalization: éàêïæøçÉÀÊÏÆØÇ},
 	author = {Somebody},

--- a/tests/bibs/field-selection.btac.bib.exp
+++ b/tests/bibs/field-selection.btac.bib.exp
@@ -3,6 +3,7 @@
 
 @comment{Outside of entries, text is just a comment}
 
+% BTAC sources: input, fake_lookup
 @misc{entry_basic,
 	title = {My awesome article},
 	author = {Yours Truly},
@@ -18,6 +19,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {1},
 }
 
+% BTAC sources: input, fake_lookup
 @article{entry_basic2,
 	title = {Something},
 	author = {Someone},
@@ -34,14 +36,17 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {2},
 }
 
+% BTAC sources: input
 @booklet{almost_empty,
 	note = {This entry shouldn't be queried, no useful data},
 }
 
+% BTAC sources: input
 @techreport{also_almost_empty,
 	foo = {bar: no standard field at all},
 }
 
+% BTAC sources: input, fake_lookup
 @article{doi,
 	title = {Generated title 5},
 	booktitle = {Generated booktitle 5},
@@ -56,6 +61,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {5},
 }
 
+% BTAC sources: input, fake_lookup
 @inproceedings{giberish,
 	title = {giberish},
 	author = {1789},
@@ -75,6 +81,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {6},
 }
 
+% BTAC sources: input
 @article{full,
 	title = {Full entry, never queried, but field order changed},
 	author = {1789},
@@ -93,6 +100,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {full},
 }
 
+% BTAC sources: input
 @misc{marked,
 	title = {marked entry is not queried},
 	btacqueried = {2024-07-19},
@@ -100,12 +108,14 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	pages = {1--150},
 }
 
+% BTAC sources: input
 @article{markedbis,
 	title = {marked entry is not queried},
 	btacqueried = {not necessarily a data},
 	doi = {10.22222/123456789},
 }
 
+% BTAC sources: input, fake_lookup
 @misc{all_fields_for_misc,
 	title = {Test for filter-by-entrytype},
 	author = {My Guy},
@@ -123,6 +133,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	year = {2015},
 }
 
+% BTAC sources: input, fake_lookup
 @misc{opt_field_for_misc,
 	title = {Test for filter-by-entrytype},
 	author = {My Guy},
@@ -139,6 +150,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	year = {2015},
 }
 
+% BTAC sources: input, fake_lookup
 @misc{req_field_for_misc,
 	title = {Test for filter-by-entrytype},
 	booktitle = {Generated booktitle 9},
@@ -153,6 +165,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {9},
 }
 
+% BTAC sources: input, fake_lookup
 @article{entry0,
 	title = {Title of entry 0},
 	booktitle = {Generated booktitle 10},
@@ -167,6 +180,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {10},
 }
 
+% BTAC sources: input, fake_lookup
 @book{entry1,
 	title = {Title of entry 1},
 	booktitle = {Generated booktitle 11},
@@ -181,6 +195,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {11},
 }
 
+% BTAC sources: input, fake_lookup
 @booklet{entry2,
 	title = {Title of entry 2},
 	booktitle = {Generated booktitle 12},
@@ -195,6 +210,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {12},
 }
 
+% BTAC sources: input, fake_lookup
 @conference{entry3,
 	title = {Title of entry 3},
 	booktitle = {Generated booktitle 13},
@@ -210,6 +226,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {13},
 }
 
+% BTAC sources: input, fake_lookup
 @inbook{entry4,
 	title = {Title of entry 4},
 	booktitle = {Generated booktitle 14},
@@ -224,6 +241,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {14},
 }
 
+% BTAC sources: input, fake_lookup
 @incollection{entry5,
 	title = {Title of entry 5},
 	booktitle = {Generated booktitle 15},
@@ -238,6 +256,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {15},
 }
 
+% BTAC sources: input, fake_lookup
 @manual{entry6,
 	title = {Title of entry 6},
 	booktitle = {Generated booktitle 16},
@@ -252,6 +271,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {16},
 }
 
+% BTAC sources: input, fake_lookup
 @mastersthesis{entry7,
 	title = {Title of entry 7},
 	booktitle = {Generated booktitle 17},
@@ -266,6 +286,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {17},
 }
 
+% BTAC sources: input, fake_lookup
 @misc{entry8,
 	title = {Title of entry 8},
 	booktitle = {Generated booktitle 18},
@@ -280,6 +301,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {18},
 }
 
+% BTAC sources: input, fake_lookup
 @techreport{entry9,
 	title = {Title of entry 9},
 	booktitle = {Generated booktitle 19},
@@ -294,6 +316,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {19},
 }
 
+% BTAC sources: input, fake_lookup
 @unpublished{entry10,
 	title = {Title of entry 10},
 	booktitle = {Generated booktitle 20},
@@ -308,6 +331,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {20},
 }
 
+% BTAC sources: input, fake_lookup
 @inproceedings{entry11,
 	title = {Title of entry 11},
 	booktitle = {Generated booktitle 21},
@@ -322,6 +346,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {21},
 }
 
+% BTAC sources: input, fake_lookup
 @phdthesis{entry12,
 	title = {Title of entry 12},
 	booktitle = {Generated booktitle 22},
@@ -336,6 +361,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {22},
 }
 
+% BTAC sources: input, fake_lookup
 @misc{with_accents,
 	title = {Lots OF accents AnD Capitalization: éàêïæøçÉÀÊÏÆØÇ},
 	author = {Somebody},

--- a/tests/bibs/format-align.btac.bib.exp
+++ b/tests/bibs/format-align.btac.bib.exp
@@ -3,6 +3,7 @@
 
 @comment{Outside of entries, text is just a comment}
 
+% BTAC sources: input, fake_lookup
 @misc{entry_basic,
 	title        = {My awesome article},
 	author       = {Yours Truly},
@@ -18,6 +19,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume       = {1},
 }
 
+% BTAC sources: input, fake_lookup
 @article{entry_basic2,
 	title        = {Something},
 	author       = {Someone},
@@ -34,14 +36,17 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume       = {2},
 }
 
+% BTAC sources: input
 @booklet{almost_empty,
 	note         = {This entry shouldn't be queried, no useful data},
 }
 
+% BTAC sources: input
 @techreport{also_almost_empty,
 	foo          = {bar: no standard field at all},
 }
 
+% BTAC sources: input, fake_lookup
 @article{doi,
 	title        = {Generated title 5},
 	author       = {Doe5, John},
@@ -57,6 +62,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume       = {5},
 }
 
+% BTAC sources: input, fake_lookup
 @inproceedings{giberish,
 	title        = {giberish},
 	author       = {1789},
@@ -76,6 +82,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume       = {6},
 }
 
+% BTAC sources: input
 @article{full,
 	title        = {Full entry, never queried, but field order changed},
 	author       = {1789},
@@ -94,6 +101,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume       = {full},
 }
 
+% BTAC sources: input
 @misc{marked,
 	title        = {marked entry is not queried},
 	btacqueried  = {2024-07-19},
@@ -101,12 +109,14 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	pages        = {1--150},
 }
 
+% BTAC sources: input
 @article{markedbis,
 	title        = {marked entry is not queried},
 	btacqueried  = {not necessarily a data},
 	doi          = {10.22222/123456789},
 }
 
+% BTAC sources: input, fake_lookup
 @misc{all_fields_for_misc,
 	title        = {Test for filter-by-entrytype},
 	author       = {My Guy},
@@ -124,6 +134,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	year         = {2015},
 }
 
+% BTAC sources: input, fake_lookup
 @misc{opt_field_for_misc,
 	title        = {Test for filter-by-entrytype},
 	author       = {My Guy},
@@ -140,6 +151,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	year         = {2015},
 }
 
+% BTAC sources: input, fake_lookup
 @misc{req_field_for_misc,
 	title        = {Test for filter-by-entrytype},
 	author       = {Doe9, John},
@@ -155,6 +167,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume       = {9},
 }
 
+% BTAC sources: input, fake_lookup
 @article{entry0,
 	title        = {Title of entry 0},
 	author       = {Doe10, John},
@@ -170,6 +183,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume       = {10},
 }
 
+% BTAC sources: input, fake_lookup
 @book{entry1,
 	title        = {Title of entry 1},
 	author       = {Doe11, John},
@@ -185,6 +199,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume       = {11},
 }
 
+% BTAC sources: input, fake_lookup
 @booklet{entry2,
 	title        = {Title of entry 2},
 	author       = {Doe12, John},
@@ -200,6 +215,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume       = {12},
 }
 
+% BTAC sources: input, fake_lookup
 @conference{entry3,
 	title        = {Title of entry 3},
 	author       = {Doe13, John},
@@ -216,6 +232,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume       = {13},
 }
 
+% BTAC sources: input, fake_lookup
 @inbook{entry4,
 	title        = {Title of entry 4},
 	author       = {Doe14, John},
@@ -231,6 +248,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume       = {14},
 }
 
+% BTAC sources: input, fake_lookup
 @incollection{entry5,
 	title        = {Title of entry 5},
 	author       = {Doe15, John},
@@ -246,6 +264,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume       = {15},
 }
 
+% BTAC sources: input, fake_lookup
 @manual{entry6,
 	title        = {Title of entry 6},
 	author       = {Doe16, John},
@@ -261,6 +280,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume       = {16},
 }
 
+% BTAC sources: input, fake_lookup
 @mastersthesis{entry7,
 	title        = {Title of entry 7},
 	author       = {Doe17, John},
@@ -276,6 +296,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume       = {17},
 }
 
+% BTAC sources: input, fake_lookup
 @misc{entry8,
 	title        = {Title of entry 8},
 	author       = {Doe18, John},
@@ -291,6 +312,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume       = {18},
 }
 
+% BTAC sources: input, fake_lookup
 @techreport{entry9,
 	title        = {Title of entry 9},
 	author       = {Doe19, John},
@@ -306,6 +328,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume       = {19},
 }
 
+% BTAC sources: input, fake_lookup
 @unpublished{entry10,
 	title        = {Title of entry 10},
 	author       = {Doe20, John},
@@ -321,6 +344,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume       = {20},
 }
 
+% BTAC sources: input, fake_lookup
 @inproceedings{entry11,
 	title        = {Title of entry 11},
 	author       = {Doe21, John},
@@ -336,6 +360,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume       = {21},
 }
 
+% BTAC sources: input, fake_lookup
 @phdthesis{entry12,
 	title        = {Title of entry 12},
 	author       = {Doe22, John},
@@ -351,6 +376,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume       = {22},
 }
 
+% BTAC sources: input, fake_lookup
 @misc{with_accents,
 	title        = {Lots OF accents AnD Capitalization: éàêïæøçÉÀÊÏÆØÇ},
 	author       = {Somebody},

--- a/tests/bibs/format-all.btac.bib.exp
+++ b/tests/bibs/format-all.btac.bib.exp
@@ -3,6 +3,7 @@
 
 @comment{Outside of entries, text is just a comment}
 
+% BTAC sources: input, fake_lookup
 @misc{entry_basic
   	, title        = {My awesome article}
   	, author       = {Yours Truly}
@@ -18,6 +19,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ}
   	, volume       = {1}
 }
 
+% BTAC sources: input, fake_lookup
 @article{entry_basic2
   	, title        = {Something}
   	, author       = {Someone}
@@ -34,14 +36,17 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ}
   	, volume       = {2}
 }
 
+% BTAC sources: input
 @booklet{almost_empty
   	, note         = {This entry shouldn't be queried, no useful data}
 }
 
+% BTAC sources: input
 @techreport{also_almost_empty
   	, foo          = {bar: no standard field at all}
 }
 
+% BTAC sources: input, fake_lookup
 @article{doi
   	, title        = {Generated title 5}
   	, author       = {Doe5, John}
@@ -57,6 +62,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ}
   	, volume       = {5}
 }
 
+% BTAC sources: input, fake_lookup
 @inproceedings{giberish
   	, title        = {giberish}
   	, author       = {1789}
@@ -76,6 +82,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ}
   	, volume       = {6}
 }
 
+% BTAC sources: input
 @article{full
   	, title        = {Full entry, never queried, but field order changed}
   	, author       = {1789}
@@ -94,6 +101,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ}
   	, volume       = {full}
 }
 
+% BTAC sources: input
 @misc{marked
   	, title        = {marked entry is not queried}
   	, btacqueried  = {2024-07-19}
@@ -101,12 +109,14 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ}
   	, pages        = {1--150}
 }
 
+% BTAC sources: input
 @article{markedbis
   	, title        = {marked entry is not queried}
   	, btacqueried  = {not necessarily a data}
   	, doi          = {10.22222/123456789}
 }
 
+% BTAC sources: input, fake_lookup
 @misc{all_fields_for_misc
   	, title        = {Test for filter-by-entrytype}
   	, author       = {My Guy}
@@ -124,6 +134,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ}
   	, year         = {2015}
 }
 
+% BTAC sources: input, fake_lookup
 @misc{opt_field_for_misc
   	, title        = {Test for filter-by-entrytype}
   	, author       = {My Guy}
@@ -140,6 +151,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ}
   	, year         = {2015}
 }
 
+% BTAC sources: input, fake_lookup
 @misc{req_field_for_misc
   	, title        = {Test for filter-by-entrytype}
   	, author       = {Doe9, John}
@@ -155,6 +167,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ}
   	, volume       = {9}
 }
 
+% BTAC sources: input, fake_lookup
 @article{entry0
   	, title        = {Title of entry 0}
   	, author       = {Doe10, John}
@@ -170,6 +183,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ}
   	, volume       = {10}
 }
 
+% BTAC sources: input, fake_lookup
 @book{entry1
   	, title        = {Title of entry 1}
   	, author       = {Doe11, John}
@@ -185,6 +199,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ}
   	, volume       = {11}
 }
 
+% BTAC sources: input, fake_lookup
 @booklet{entry2
   	, title        = {Title of entry 2}
   	, author       = {Doe12, John}
@@ -200,6 +215,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ}
   	, volume       = {12}
 }
 
+% BTAC sources: input, fake_lookup
 @conference{entry3
   	, title        = {Title of entry 3}
   	, author       = {Doe13, John}
@@ -216,6 +232,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ}
   	, volume       = {13}
 }
 
+% BTAC sources: input, fake_lookup
 @inbook{entry4
   	, title        = {Title of entry 4}
   	, author       = {Doe14, John}
@@ -231,6 +248,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ}
   	, volume       = {14}
 }
 
+% BTAC sources: input, fake_lookup
 @incollection{entry5
   	, title        = {Title of entry 5}
   	, author       = {Doe15, John}
@@ -246,6 +264,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ}
   	, volume       = {15}
 }
 
+% BTAC sources: input, fake_lookup
 @manual{entry6
   	, title        = {Title of entry 6}
   	, author       = {Doe16, John}
@@ -261,6 +280,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ}
   	, volume       = {16}
 }
 
+% BTAC sources: input, fake_lookup
 @mastersthesis{entry7
   	, title        = {Title of entry 7}
   	, author       = {Doe17, John}
@@ -276,6 +296,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ}
   	, volume       = {17}
 }
 
+% BTAC sources: input, fake_lookup
 @misc{entry8
   	, title        = {Title of entry 8}
   	, author       = {Doe18, John}
@@ -291,6 +312,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ}
   	, volume       = {18}
 }
 
+% BTAC sources: input, fake_lookup
 @techreport{entry9
   	, title        = {Title of entry 9}
   	, author       = {Doe19, John}
@@ -306,6 +328,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ}
   	, volume       = {19}
 }
 
+% BTAC sources: input, fake_lookup
 @unpublished{entry10
   	, title        = {Title of entry 10}
   	, author       = {Doe20, John}
@@ -321,6 +344,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ}
   	, volume       = {20}
 }
 
+% BTAC sources: input, fake_lookup
 @inproceedings{entry11
   	, title        = {Title of entry 11}
   	, author       = {Doe21, John}
@@ -336,6 +360,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ}
   	, volume       = {21}
 }
 
+% BTAC sources: input, fake_lookup
 @phdthesis{entry12
   	, title        = {Title of entry 12}
   	, author       = {Doe22, John}
@@ -351,6 +376,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ}
   	, volume       = {22}
 }
 
+% BTAC sources: input, fake_lookup
 @misc{with_accents
   	, title        = {Lots OF accents AnD Capitalization: éàêïæøçÉÀÊÏÆØÇ}
   	, author       = {Somebody}

--- a/tests/bibs/format-comma.btac.bib.exp
+++ b/tests/bibs/format-comma.btac.bib.exp
@@ -3,6 +3,7 @@
 
 @comment{Outside of entries, text is just a comment}
 
+% BTAC sources: input, fake_lookup
 @misc{entry_basic,
 	title = {My awesome article},
 	author = {Yours Truly},
@@ -18,6 +19,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {1}
 }
 
+% BTAC sources: input, fake_lookup
 @article{entry_basic2,
 	title = {Something},
 	author = {Someone},
@@ -34,14 +36,17 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {2}
 }
 
+% BTAC sources: input
 @booklet{almost_empty,
 	note = {This entry shouldn't be queried, no useful data}
 }
 
+% BTAC sources: input
 @techreport{also_almost_empty,
 	foo = {bar: no standard field at all}
 }
 
+% BTAC sources: input, fake_lookup
 @article{doi,
 	title = {Generated title 5},
 	author = {Doe5, John},
@@ -57,6 +62,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {5}
 }
 
+% BTAC sources: input, fake_lookup
 @inproceedings{giberish,
 	title = {giberish},
 	author = {1789},
@@ -76,6 +82,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {6}
 }
 
+% BTAC sources: input
 @article{full,
 	title = {Full entry, never queried, but field order changed},
 	author = {1789},
@@ -94,6 +101,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {full}
 }
 
+% BTAC sources: input
 @misc{marked,
 	title = {marked entry is not queried},
 	btacqueried = {2024-07-19},
@@ -101,12 +109,14 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	pages = {1--150}
 }
 
+% BTAC sources: input
 @article{markedbis,
 	title = {marked entry is not queried},
 	btacqueried = {not necessarily a data},
 	doi = {10.22222/123456789}
 }
 
+% BTAC sources: input, fake_lookup
 @misc{all_fields_for_misc,
 	title = {Test for filter-by-entrytype},
 	author = {My Guy},
@@ -124,6 +134,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	year = {2015}
 }
 
+% BTAC sources: input, fake_lookup
 @misc{opt_field_for_misc,
 	title = {Test for filter-by-entrytype},
 	author = {My Guy},
@@ -140,6 +151,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	year = {2015}
 }
 
+% BTAC sources: input, fake_lookup
 @misc{req_field_for_misc,
 	title = {Test for filter-by-entrytype},
 	author = {Doe9, John},
@@ -155,6 +167,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {9}
 }
 
+% BTAC sources: input, fake_lookup
 @article{entry0,
 	title = {Title of entry 0},
 	author = {Doe10, John},
@@ -170,6 +183,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {10}
 }
 
+% BTAC sources: input, fake_lookup
 @book{entry1,
 	title = {Title of entry 1},
 	author = {Doe11, John},
@@ -185,6 +199,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {11}
 }
 
+% BTAC sources: input, fake_lookup
 @booklet{entry2,
 	title = {Title of entry 2},
 	author = {Doe12, John},
@@ -200,6 +215,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {12}
 }
 
+% BTAC sources: input, fake_lookup
 @conference{entry3,
 	title = {Title of entry 3},
 	author = {Doe13, John},
@@ -216,6 +232,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {13}
 }
 
+% BTAC sources: input, fake_lookup
 @inbook{entry4,
 	title = {Title of entry 4},
 	author = {Doe14, John},
@@ -231,6 +248,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {14}
 }
 
+% BTAC sources: input, fake_lookup
 @incollection{entry5,
 	title = {Title of entry 5},
 	author = {Doe15, John},
@@ -246,6 +264,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {15}
 }
 
+% BTAC sources: input, fake_lookup
 @manual{entry6,
 	title = {Title of entry 6},
 	author = {Doe16, John},
@@ -261,6 +280,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {16}
 }
 
+% BTAC sources: input, fake_lookup
 @mastersthesis{entry7,
 	title = {Title of entry 7},
 	author = {Doe17, John},
@@ -276,6 +296,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {17}
 }
 
+% BTAC sources: input, fake_lookup
 @misc{entry8,
 	title = {Title of entry 8},
 	author = {Doe18, John},
@@ -291,6 +312,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {18}
 }
 
+% BTAC sources: input, fake_lookup
 @techreport{entry9,
 	title = {Title of entry 9},
 	author = {Doe19, John},
@@ -306,6 +328,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {19}
 }
 
+% BTAC sources: input, fake_lookup
 @unpublished{entry10,
 	title = {Title of entry 10},
 	author = {Doe20, John},
@@ -321,6 +344,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {20}
 }
 
+% BTAC sources: input, fake_lookup
 @inproceedings{entry11,
 	title = {Title of entry 11},
 	author = {Doe21, John},
@@ -336,6 +360,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {21}
 }
 
+% BTAC sources: input, fake_lookup
 @phdthesis{entry12,
 	title = {Title of entry 12},
 	author = {Doe22, John},
@@ -351,6 +376,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {22}
 }
 
+% BTAC sources: input, fake_lookup
 @misc{with_accents,
 	title = {Lots OF accents AnD Capitalization: éàêïæøçÉÀÊÏÆØÇ},
 	author = {Somebody},

--- a/tests/bibs/format-leading.btac.bib.exp
+++ b/tests/bibs/format-leading.btac.bib.exp
@@ -3,6 +3,7 @@
 
 @comment{Outside of entries, text is just a comment}
 
+% BTAC sources: input, fake_lookup
 @misc{entry_basic
 	, title = {My awesome article}
 	, author = {Yours Truly}
@@ -19,6 +20,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ}
 	,
 }
 
+% BTAC sources: input, fake_lookup
 @article{entry_basic2
 	, title = {Something}
 	, author = {Someone}
@@ -36,16 +38,19 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ}
 	,
 }
 
+% BTAC sources: input
 @booklet{almost_empty
 	, note = {This entry shouldn't be queried, no useful data}
 	,
 }
 
+% BTAC sources: input
 @techreport{also_almost_empty
 	, foo = {bar: no standard field at all}
 	,
 }
 
+% BTAC sources: input, fake_lookup
 @article{doi
 	, title = {Generated title 5}
 	, author = {Doe5, John}
@@ -62,6 +67,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ}
 	,
 }
 
+% BTAC sources: input, fake_lookup
 @inproceedings{giberish
 	, title = {giberish}
 	, author = {1789}
@@ -82,6 +88,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ}
 	,
 }
 
+% BTAC sources: input
 @article{full
 	, title = {Full entry, never queried, but field order changed}
 	, author = {1789}
@@ -101,6 +108,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ}
 	,
 }
 
+% BTAC sources: input
 @misc{marked
 	, title = {marked entry is not queried}
 	, btacqueried = {2024-07-19}
@@ -109,6 +117,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ}
 	,
 }
 
+% BTAC sources: input
 @article{markedbis
 	, title = {marked entry is not queried}
 	, btacqueried = {not necessarily a data}
@@ -116,6 +125,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ}
 	,
 }
 
+% BTAC sources: input, fake_lookup
 @misc{all_fields_for_misc
 	, title = {Test for filter-by-entrytype}
 	, author = {My Guy}
@@ -134,6 +144,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ}
 	,
 }
 
+% BTAC sources: input, fake_lookup
 @misc{opt_field_for_misc
 	, title = {Test for filter-by-entrytype}
 	, author = {My Guy}
@@ -151,6 +162,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ}
 	,
 }
 
+% BTAC sources: input, fake_lookup
 @misc{req_field_for_misc
 	, title = {Test for filter-by-entrytype}
 	, author = {Doe9, John}
@@ -167,6 +179,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ}
 	,
 }
 
+% BTAC sources: input, fake_lookup
 @article{entry0
 	, title = {Title of entry 0}
 	, author = {Doe10, John}
@@ -183,6 +196,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ}
 	,
 }
 
+% BTAC sources: input, fake_lookup
 @book{entry1
 	, title = {Title of entry 1}
 	, author = {Doe11, John}
@@ -199,6 +213,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ}
 	,
 }
 
+% BTAC sources: input, fake_lookup
 @booklet{entry2
 	, title = {Title of entry 2}
 	, author = {Doe12, John}
@@ -215,6 +230,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ}
 	,
 }
 
+% BTAC sources: input, fake_lookup
 @conference{entry3
 	, title = {Title of entry 3}
 	, author = {Doe13, John}
@@ -232,6 +248,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ}
 	,
 }
 
+% BTAC sources: input, fake_lookup
 @inbook{entry4
 	, title = {Title of entry 4}
 	, author = {Doe14, John}
@@ -248,6 +265,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ}
 	,
 }
 
+% BTAC sources: input, fake_lookup
 @incollection{entry5
 	, title = {Title of entry 5}
 	, author = {Doe15, John}
@@ -264,6 +282,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ}
 	,
 }
 
+% BTAC sources: input, fake_lookup
 @manual{entry6
 	, title = {Title of entry 6}
 	, author = {Doe16, John}
@@ -280,6 +299,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ}
 	,
 }
 
+% BTAC sources: input, fake_lookup
 @mastersthesis{entry7
 	, title = {Title of entry 7}
 	, author = {Doe17, John}
@@ -296,6 +316,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ}
 	,
 }
 
+% BTAC sources: input, fake_lookup
 @misc{entry8
 	, title = {Title of entry 8}
 	, author = {Doe18, John}
@@ -312,6 +333,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ}
 	,
 }
 
+% BTAC sources: input, fake_lookup
 @techreport{entry9
 	, title = {Title of entry 9}
 	, author = {Doe19, John}
@@ -328,6 +350,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ}
 	,
 }
 
+% BTAC sources: input, fake_lookup
 @unpublished{entry10
 	, title = {Title of entry 10}
 	, author = {Doe20, John}
@@ -344,6 +367,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ}
 	,
 }
 
+% BTAC sources: input, fake_lookup
 @inproceedings{entry11
 	, title = {Title of entry 11}
 	, author = {Doe21, John}
@@ -360,6 +384,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ}
 	,
 }
 
+% BTAC sources: input, fake_lookup
 @phdthesis{entry12
 	, title = {Title of entry 12}
 	, author = {Doe22, John}
@@ -376,6 +401,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ}
 	,
 }
 
+% BTAC sources: input, fake_lookup
 @misc{with_accents
 	, title = {Lots OF accents AnD Capitalization: éàêïæøçÉÀÊÏÆØÇ}
 	, author = {Somebody}

--- a/tests/bibs/format-space.btac.bib.exp
+++ b/tests/bibs/format-space.btac.bib.exp
@@ -3,6 +3,7 @@
 
 @comment{Outside of entries, text is just a comment}
 
+% BTAC sources: input, fake_lookup
 @misc{entry_basic,
   title = {My awesome article},
   author = {Yours Truly},
@@ -18,6 +19,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
   volume = {1},
 }
 
+% BTAC sources: input, fake_lookup
 @article{entry_basic2,
   title = {Something},
   author = {Someone},
@@ -34,14 +36,17 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
   volume = {2},
 }
 
+% BTAC sources: input
 @booklet{almost_empty,
   note = {This entry shouldn't be queried, no useful data},
 }
 
+% BTAC sources: input
 @techreport{also_almost_empty,
   foo = {bar: no standard field at all},
 }
 
+% BTAC sources: input, fake_lookup
 @article{doi,
   title = {Generated title 5},
   author = {Doe5, John},
@@ -57,6 +62,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
   volume = {5},
 }
 
+% BTAC sources: input, fake_lookup
 @inproceedings{giberish,
   title = {giberish},
   author = {1789},
@@ -76,6 +82,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
   volume = {6},
 }
 
+% BTAC sources: input
 @article{full,
   title = {Full entry, never queried, but field order changed},
   author = {1789},
@@ -94,6 +101,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
   volume = {full},
 }
 
+% BTAC sources: input
 @misc{marked,
   title = {marked entry is not queried},
   btacqueried = {2024-07-19},
@@ -101,12 +109,14 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
   pages = {1--150},
 }
 
+% BTAC sources: input
 @article{markedbis,
   title = {marked entry is not queried},
   btacqueried = {not necessarily a data},
   doi = {10.22222/123456789},
 }
 
+% BTAC sources: input, fake_lookup
 @misc{all_fields_for_misc,
   title = {Test for filter-by-entrytype},
   author = {My Guy},
@@ -124,6 +134,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
   year = {2015},
 }
 
+% BTAC sources: input, fake_lookup
 @misc{opt_field_for_misc,
   title = {Test for filter-by-entrytype},
   author = {My Guy},
@@ -140,6 +151,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
   year = {2015},
 }
 
+% BTAC sources: input, fake_lookup
 @misc{req_field_for_misc,
   title = {Test for filter-by-entrytype},
   author = {Doe9, John},
@@ -155,6 +167,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
   volume = {9},
 }
 
+% BTAC sources: input, fake_lookup
 @article{entry0,
   title = {Title of entry 0},
   author = {Doe10, John},
@@ -170,6 +183,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
   volume = {10},
 }
 
+% BTAC sources: input, fake_lookup
 @book{entry1,
   title = {Title of entry 1},
   author = {Doe11, John},
@@ -185,6 +199,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
   volume = {11},
 }
 
+% BTAC sources: input, fake_lookup
 @booklet{entry2,
   title = {Title of entry 2},
   author = {Doe12, John},
@@ -200,6 +215,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
   volume = {12},
 }
 
+% BTAC sources: input, fake_lookup
 @conference{entry3,
   title = {Title of entry 3},
   author = {Doe13, John},
@@ -216,6 +232,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
   volume = {13},
 }
 
+% BTAC sources: input, fake_lookup
 @inbook{entry4,
   title = {Title of entry 4},
   author = {Doe14, John},
@@ -231,6 +248,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
   volume = {14},
 }
 
+% BTAC sources: input, fake_lookup
 @incollection{entry5,
   title = {Title of entry 5},
   author = {Doe15, John},
@@ -246,6 +264,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
   volume = {15},
 }
 
+% BTAC sources: input, fake_lookup
 @manual{entry6,
   title = {Title of entry 6},
   author = {Doe16, John},
@@ -261,6 +280,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
   volume = {16},
 }
 
+% BTAC sources: input, fake_lookup
 @mastersthesis{entry7,
   title = {Title of entry 7},
   author = {Doe17, John},
@@ -276,6 +296,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
   volume = {17},
 }
 
+% BTAC sources: input, fake_lookup
 @misc{entry8,
   title = {Title of entry 8},
   author = {Doe18, John},
@@ -291,6 +312,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
   volume = {18},
 }
 
+% BTAC sources: input, fake_lookup
 @techreport{entry9,
   title = {Title of entry 9},
   author = {Doe19, John},
@@ -306,6 +328,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
   volume = {19},
 }
 
+% BTAC sources: input, fake_lookup
 @unpublished{entry10,
   title = {Title of entry 10},
   author = {Doe20, John},
@@ -321,6 +344,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
   volume = {20},
 }
 
+% BTAC sources: input, fake_lookup
 @inproceedings{entry11,
   title = {Title of entry 11},
   author = {Doe21, John},
@@ -336,6 +360,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
   volume = {21},
 }
 
+% BTAC sources: input, fake_lookup
 @phdthesis{entry12,
   title = {Title of entry 12},
   author = {Doe22, John},
@@ -351,6 +376,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
   volume = {22},
 }
 
+% BTAC sources: input, fake_lookup
 @misc{with_accents,
   title = {Lots OF accents AnD Capitalization: éàêïæøçÉÀÊÏÆØÇ},
   author = {Somebody},

--- a/tests/bibs/format-space2.btac.bib.exp
+++ b/tests/bibs/format-space2.btac.bib.exp
@@ -3,6 +3,7 @@
 
 @comment{Outside of entries, text is just a comment}
 
+% BTAC sources: input, fake_lookup
 @misc{entry_basic,
   
 	title = {My awesome article},
@@ -29,6 +30,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {1},
 }
 
+% BTAC sources: input, fake_lookup
 @article{entry_basic2,
   
 	title = {Something},
@@ -57,16 +59,19 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {2},
 }
 
+% BTAC sources: input
 @booklet{almost_empty,
   
 	note = {This entry shouldn't be queried, no useful data},
 }
 
+% BTAC sources: input
 @techreport{also_almost_empty,
   
 	foo = {bar: no standard field at all},
 }
 
+% BTAC sources: input, fake_lookup
 @article{doi,
   
 	title = {Generated title 5},
@@ -93,6 +98,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {5},
 }
 
+% BTAC sources: input, fake_lookup
 @inproceedings{giberish,
   
 	title = {giberish},
@@ -127,6 +133,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {6},
 }
 
+% BTAC sources: input
 @article{full,
   
 	title = {Full entry, never queried, but field order changed},
@@ -160,6 +167,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {full},
 }
 
+% BTAC sources: input
 @misc{marked,
   
 	title = {marked entry is not queried},
@@ -171,6 +179,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	pages = {1--150},
 }
 
+% BTAC sources: input
 @article{markedbis,
   
 	title = {marked entry is not queried},
@@ -180,6 +189,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	doi = {10.22222/123456789},
 }
 
+% BTAC sources: input, fake_lookup
 @misc{all_fields_for_misc,
   
 	title = {Test for filter-by-entrytype},
@@ -211,6 +221,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	year = {2015},
 }
 
+% BTAC sources: input, fake_lookup
 @misc{opt_field_for_misc,
   
 	title = {Test for filter-by-entrytype},
@@ -240,6 +251,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	year = {2015},
 }
 
+% BTAC sources: input, fake_lookup
 @misc{req_field_for_misc,
   
 	title = {Test for filter-by-entrytype},
@@ -266,6 +278,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {9},
 }
 
+% BTAC sources: input, fake_lookup
 @article{entry0,
   
 	title = {Title of entry 0},
@@ -292,6 +305,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {10},
 }
 
+% BTAC sources: input, fake_lookup
 @book{entry1,
   
 	title = {Title of entry 1},
@@ -318,6 +332,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {11},
 }
 
+% BTAC sources: input, fake_lookup
 @booklet{entry2,
   
 	title = {Title of entry 2},
@@ -344,6 +359,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {12},
 }
 
+% BTAC sources: input, fake_lookup
 @conference{entry3,
   
 	title = {Title of entry 3},
@@ -372,6 +388,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {13},
 }
 
+% BTAC sources: input, fake_lookup
 @inbook{entry4,
   
 	title = {Title of entry 4},
@@ -398,6 +415,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {14},
 }
 
+% BTAC sources: input, fake_lookup
 @incollection{entry5,
   
 	title = {Title of entry 5},
@@ -424,6 +442,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {15},
 }
 
+% BTAC sources: input, fake_lookup
 @manual{entry6,
   
 	title = {Title of entry 6},
@@ -450,6 +469,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {16},
 }
 
+% BTAC sources: input, fake_lookup
 @mastersthesis{entry7,
   
 	title = {Title of entry 7},
@@ -476,6 +496,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {17},
 }
 
+% BTAC sources: input, fake_lookup
 @misc{entry8,
   
 	title = {Title of entry 8},
@@ -502,6 +523,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {18},
 }
 
+% BTAC sources: input, fake_lookup
 @techreport{entry9,
   
 	title = {Title of entry 9},
@@ -528,6 +550,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {19},
 }
 
+% BTAC sources: input, fake_lookup
 @unpublished{entry10,
   
 	title = {Title of entry 10},
@@ -554,6 +577,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {20},
 }
 
+% BTAC sources: input, fake_lookup
 @inproceedings{entry11,
   
 	title = {Title of entry 11},
@@ -580,6 +604,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {21},
 }
 
+% BTAC sources: input, fake_lookup
 @phdthesis{entry12,
   
 	title = {Title of entry 12},
@@ -606,6 +631,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {22},
 }
 
+% BTAC sources: input, fake_lookup
 @misc{with_accents,
   
 	title = {Lots OF accents AnD Capitalization: éàêïæøçÉÀÊÏÆØÇ},

--- a/tests/bibs/format-unicode.btac.bib.exp
+++ b/tests/bibs/format-unicode.btac.bib.exp
@@ -3,6 +3,7 @@
 
 @comment{Outside of entries, text is just a comment}
 
+% BTAC sources: input, fake_lookup
 @misc{entry_basic,
 	title = {My awesome article},
 	author = {Yours Truly},
@@ -18,6 +19,7 @@ Newline UppERcaSE AND accents: {\'e}{\`a}{\^e}{\"\i}{\ae}{\o}{\c c}{\'E}{\`A}{\^
 	volume = {1},
 }
 
+% BTAC sources: input, fake_lookup
 @article{entry_basic2,
 	title = {Something},
 	author = {Someone},
@@ -34,14 +36,17 @@ Newline UppERcaSE AND accents: {\'e}{\`a}{\^e}{\"\i}{\ae}{\o}{\c c}{\'E}{\`A}{\^
 	volume = {2},
 }
 
+% BTAC sources: input
 @booklet{almost_empty,
 	note = {This entry shouldn't be queried, no useful data},
 }
 
+% BTAC sources: input
 @techreport{also_almost_empty,
 	foo = {bar: no standard field at all},
 }
 
+% BTAC sources: input, fake_lookup
 @article{doi,
 	title = {Generated title 5},
 	author = {Doe5, John},
@@ -57,6 +62,7 @@ Newline UppERcaSE AND accents: {\'e}{\`a}{\^e}{\"\i}{\ae}{\o}{\c c}{\'E}{\`A}{\^
 	volume = {5},
 }
 
+% BTAC sources: input, fake_lookup
 @inproceedings{giberish,
 	title = {giberish},
 	author = {1789},
@@ -76,6 +82,7 @@ Newline UppERcaSE AND accents: {\'e}{\`a}{\^e}{\"\i}{\ae}{\o}{\c c}{\'E}{\`A}{\^
 	volume = {6},
 }
 
+% BTAC sources: input
 @article{full,
 	title = {Full entry, never queried, but field order changed},
 	author = {1789},
@@ -94,6 +101,7 @@ Newline UppERcaSE AND accents: {\'e}{\`a}{\^e}{\"\i}{\ae}{\o}{\c c}{\'E}{\`A}{\^
 	volume = {full},
 }
 
+% BTAC sources: input
 @misc{marked,
 	title = {marked entry is not queried},
 	btacqueried = {2024-07-19},
@@ -101,12 +109,14 @@ Newline UppERcaSE AND accents: {\'e}{\`a}{\^e}{\"\i}{\ae}{\o}{\c c}{\'E}{\`A}{\^
 	pages = {1--150},
 }
 
+% BTAC sources: input
 @article{markedbis,
 	title = {marked entry is not queried},
 	btacqueried = {not necessarily a data},
 	doi = {10.22222/123456789},
 }
 
+% BTAC sources: input, fake_lookup
 @misc{all_fields_for_misc,
 	title = {Test for filter-by-entrytype},
 	author = {My Guy},
@@ -124,6 +134,7 @@ Newline UppERcaSE AND accents: {\'e}{\`a}{\^e}{\"\i}{\ae}{\o}{\c c}{\'E}{\`A}{\^
 	year = {2015},
 }
 
+% BTAC sources: input, fake_lookup
 @misc{opt_field_for_misc,
 	title = {Test for filter-by-entrytype},
 	author = {My Guy},
@@ -140,6 +151,7 @@ Newline UppERcaSE AND accents: {\'e}{\`a}{\^e}{\"\i}{\ae}{\o}{\c c}{\'E}{\`A}{\^
 	year = {2015},
 }
 
+% BTAC sources: input, fake_lookup
 @misc{req_field_for_misc,
 	title = {Test for filter-by-entrytype},
 	author = {Doe9, John},
@@ -155,6 +167,7 @@ Newline UppERcaSE AND accents: {\'e}{\`a}{\^e}{\"\i}{\ae}{\o}{\c c}{\'E}{\`A}{\^
 	volume = {9},
 }
 
+% BTAC sources: input, fake_lookup
 @article{entry0,
 	title = {Title of entry 0},
 	author = {Doe10, John},
@@ -170,6 +183,7 @@ Newline UppERcaSE AND accents: {\'e}{\`a}{\^e}{\"\i}{\ae}{\o}{\c c}{\'E}{\`A}{\^
 	volume = {10},
 }
 
+% BTAC sources: input, fake_lookup
 @book{entry1,
 	title = {Title of entry 1},
 	author = {Doe11, John},
@@ -185,6 +199,7 @@ Newline UppERcaSE AND accents: {\'e}{\`a}{\^e}{\"\i}{\ae}{\o}{\c c}{\'E}{\`A}{\^
 	volume = {11},
 }
 
+% BTAC sources: input, fake_lookup
 @booklet{entry2,
 	title = {Title of entry 2},
 	author = {Doe12, John},
@@ -200,6 +215,7 @@ Newline UppERcaSE AND accents: {\'e}{\`a}{\^e}{\"\i}{\ae}{\o}{\c c}{\'E}{\`A}{\^
 	volume = {12},
 }
 
+% BTAC sources: input, fake_lookup
 @conference{entry3,
 	title = {Title of entry 3},
 	author = {Doe13, John},
@@ -216,6 +232,7 @@ Newline UppERcaSE AND accents: {\'e}{\`a}{\^e}{\"\i}{\ae}{\o}{\c c}{\'E}{\`A}{\^
 	volume = {13},
 }
 
+% BTAC sources: input, fake_lookup
 @inbook{entry4,
 	title = {Title of entry 4},
 	author = {Doe14, John},
@@ -231,6 +248,7 @@ Newline UppERcaSE AND accents: {\'e}{\`a}{\^e}{\"\i}{\ae}{\o}{\c c}{\'E}{\`A}{\^
 	volume = {14},
 }
 
+% BTAC sources: input, fake_lookup
 @incollection{entry5,
 	title = {Title of entry 5},
 	author = {Doe15, John},
@@ -246,6 +264,7 @@ Newline UppERcaSE AND accents: {\'e}{\`a}{\^e}{\"\i}{\ae}{\o}{\c c}{\'E}{\`A}{\^
 	volume = {15},
 }
 
+% BTAC sources: input, fake_lookup
 @manual{entry6,
 	title = {Title of entry 6},
 	author = {Doe16, John},
@@ -261,6 +280,7 @@ Newline UppERcaSE AND accents: {\'e}{\`a}{\^e}{\"\i}{\ae}{\o}{\c c}{\'E}{\`A}{\^
 	volume = {16},
 }
 
+% BTAC sources: input, fake_lookup
 @mastersthesis{entry7,
 	title = {Title of entry 7},
 	author = {Doe17, John},
@@ -276,6 +296,7 @@ Newline UppERcaSE AND accents: {\'e}{\`a}{\^e}{\"\i}{\ae}{\o}{\c c}{\'E}{\`A}{\^
 	volume = {17},
 }
 
+% BTAC sources: input, fake_lookup
 @misc{entry8,
 	title = {Title of entry 8},
 	author = {Doe18, John},
@@ -291,6 +312,7 @@ Newline UppERcaSE AND accents: {\'e}{\`a}{\^e}{\"\i}{\ae}{\o}{\c c}{\'E}{\`A}{\^
 	volume = {18},
 }
 
+% BTAC sources: input, fake_lookup
 @techreport{entry9,
 	title = {Title of entry 9},
 	author = {Doe19, John},
@@ -306,6 +328,7 @@ Newline UppERcaSE AND accents: {\'e}{\`a}{\^e}{\"\i}{\ae}{\o}{\c c}{\'E}{\`A}{\^
 	volume = {19},
 }
 
+% BTAC sources: input, fake_lookup
 @unpublished{entry10,
 	title = {Title of entry 10},
 	author = {Doe20, John},
@@ -321,6 +344,7 @@ Newline UppERcaSE AND accents: {\'e}{\`a}{\^e}{\"\i}{\ae}{\o}{\c c}{\'E}{\`A}{\^
 	volume = {20},
 }
 
+% BTAC sources: input, fake_lookup
 @inproceedings{entry11,
 	title = {Title of entry 11},
 	author = {Doe21, John},
@@ -336,6 +360,7 @@ Newline UppERcaSE AND accents: {\'e}{\`a}{\^e}{\"\i}{\ae}{\o}{\c c}{\'E}{\`A}{\^
 	volume = {21},
 }
 
+% BTAC sources: input, fake_lookup
 @phdthesis{entry12,
 	title = {Title of entry 12},
 	author = {Doe22, John},
@@ -351,6 +376,7 @@ Newline UppERcaSE AND accents: {\'e}{\`a}{\^e}{\"\i}{\ae}{\o}{\c c}{\'E}{\`A}{\^
 	volume = {22},
 }
 
+% BTAC sources: input, fake_lookup
 @misc{with_accents,
 	title = {Lots OF accents AnD Capitalization: éàêïæøçÉÀÊÏÆØÇ},
 	author = {Somebody},

--- a/tests/bibs/format-uppercase-all.btac.bib.exp
+++ b/tests/bibs/format-uppercase-all.btac.bib.exp
@@ -3,6 +3,7 @@
 
 @comment{Outside of entries, text is just a comment}
 
+% BTAC sources: input, fake_lookup
 @misc{entry_basic,
 	title = {My awesome article},
 	author = {Yours Truly},
@@ -18,6 +19,7 @@
 	volume = {1},
 }
 
+% BTAC sources: input, fake_lookup
 @article{entry_basic2,
 	title = {Something},
 	author = {Someone},
@@ -34,14 +36,17 @@
 	volume = {2},
 }
 
+% BTAC sources: input
 @booklet{almost_empty,
 	note = {This entry shouldn't be queried, no useful data},
 }
 
+% BTAC sources: input
 @techreport{also_almost_empty,
 	foo = {bar: no standard field at all},
 }
 
+% BTAC sources: input, fake_lookup
 @article{doi,
 	title = {{Generated} title 5},
 	author = {{Doe}5, {John}},
@@ -57,6 +62,7 @@
 	volume = {5},
 }
 
+% BTAC sources: input, fake_lookup
 @inproceedings{giberish,
 	title = {giberish},
 	author = {1789},
@@ -76,6 +82,7 @@
 	volume = {6},
 }
 
+% BTAC sources: input
 @article{full,
 	title = {Full entry, never queried, but field order changed},
 	author = {1789},
@@ -94,6 +101,7 @@
 	volume = {full},
 }
 
+% BTAC sources: input
 @misc{marked,
 	title = {marked entry is not queried},
 	btacqueried = {2024-07-19},
@@ -101,12 +109,14 @@
 	pages = {1--150},
 }
 
+% BTAC sources: input
 @article{markedbis,
 	title = {marked entry is not queried},
 	btacqueried = {not necessarily a data},
 	doi = {10.22222/123456789},
 }
 
+% BTAC sources: input, fake_lookup
 @misc{all_fields_for_misc,
 	title = {Test for filter-by-entrytype},
 	author = {My Guy},
@@ -124,6 +134,7 @@
 	year = {2015},
 }
 
+% BTAC sources: input, fake_lookup
 @misc{opt_field_for_misc,
 	title = {Test for filter-by-entrytype},
 	author = {My Guy},
@@ -140,6 +151,7 @@
 	year = {2015},
 }
 
+% BTAC sources: input, fake_lookup
 @misc{req_field_for_misc,
 	title = {Test for filter-by-entrytype},
 	author = {{Doe}9, {John}},
@@ -155,6 +167,7 @@
 	volume = {9},
 }
 
+% BTAC sources: input, fake_lookup
 @article{entry0,
 	title = {Title of entry 0},
 	author = {{Doe}10, {John}},
@@ -170,6 +183,7 @@
 	volume = {10},
 }
 
+% BTAC sources: input, fake_lookup
 @book{entry1,
 	title = {Title of entry 1},
 	author = {{Doe}11, {John}},
@@ -185,6 +199,7 @@
 	volume = {11},
 }
 
+% BTAC sources: input, fake_lookup
 @booklet{entry2,
 	title = {Title of entry 2},
 	author = {{Doe}12, {John}},
@@ -200,6 +215,7 @@
 	volume = {12},
 }
 
+% BTAC sources: input, fake_lookup
 @conference{entry3,
 	title = {Title of entry 3},
 	author = {{Doe}13, {John}},
@@ -216,6 +232,7 @@
 	volume = {13},
 }
 
+% BTAC sources: input, fake_lookup
 @inbook{entry4,
 	title = {Title of entry 4},
 	author = {{Doe}14, {John}},
@@ -231,6 +248,7 @@
 	volume = {14},
 }
 
+% BTAC sources: input, fake_lookup
 @incollection{entry5,
 	title = {Title of entry 5},
 	author = {{Doe}15, {John}},
@@ -246,6 +264,7 @@
 	volume = {15},
 }
 
+% BTAC sources: input, fake_lookup
 @manual{entry6,
 	title = {Title of entry 6},
 	author = {{Doe}16, {John}},
@@ -261,6 +280,7 @@
 	volume = {16},
 }
 
+% BTAC sources: input, fake_lookup
 @mastersthesis{entry7,
 	title = {Title of entry 7},
 	author = {{Doe}17, {John}},
@@ -276,6 +296,7 @@
 	volume = {17},
 }
 
+% BTAC sources: input, fake_lookup
 @misc{entry8,
 	title = {Title of entry 8},
 	author = {{Doe}18, {John}},
@@ -291,6 +312,7 @@
 	volume = {18},
 }
 
+% BTAC sources: input, fake_lookup
 @techreport{entry9,
 	title = {Title of entry 9},
 	author = {{Doe}19, {John}},
@@ -306,6 +328,7 @@
 	volume = {19},
 }
 
+% BTAC sources: input, fake_lookup
 @unpublished{entry10,
 	title = {Title of entry 10},
 	author = {{Doe}20, {John}},
@@ -321,6 +344,7 @@
 	volume = {20},
 }
 
+% BTAC sources: input, fake_lookup
 @inproceedings{entry11,
 	title = {Title of entry 11},
 	author = {{Doe}21, {John}},
@@ -336,6 +360,7 @@
 	volume = {21},
 }
 
+% BTAC sources: input, fake_lookup
 @phdthesis{entry12,
 	title = {Title of entry 12},
 	author = {{Doe}22, {John}},
@@ -351,6 +376,7 @@
 	volume = {22},
 }
 
+% BTAC sources: input, fake_lookup
 @misc{with_accents,
 	title = {Lots OF accents AnD Capitalization: éàêïæøçÉÀÊÏÆØÇ},
 	author = {Somebody},

--- a/tests/bibs/format-uppercase-unicode.btac.bib.exp
+++ b/tests/bibs/format-uppercase-unicode.btac.bib.exp
@@ -3,6 +3,7 @@
 
 @comment{Outside of entries, text is just a comment}
 
+% BTAC sources: input, fake_lookup
 @misc{entry_basic,
 	title = {My awesome article},
 	author = {Yours Truly},
@@ -18,6 +19,7 @@
 	volume = {1},
 }
 
+% BTAC sources: input, fake_lookup
 @article{entry_basic2,
 	title = {Something},
 	author = {Someone},
@@ -34,14 +36,17 @@
 	volume = {2},
 }
 
+% BTAC sources: input
 @booklet{almost_empty,
 	note = {This entry shouldn't be queried, no useful data},
 }
 
+% BTAC sources: input
 @techreport{also_almost_empty,
 	foo = {bar: no standard field at all},
 }
 
+% BTAC sources: input, fake_lookup
 @article{doi,
 	title = {{Generated} title 5},
 	author = {{Doe}5, {John}},
@@ -57,6 +62,7 @@
 	volume = {5},
 }
 
+% BTAC sources: input, fake_lookup
 @inproceedings{giberish,
 	title = {giberish},
 	author = {1789},
@@ -76,6 +82,7 @@
 	volume = {6},
 }
 
+% BTAC sources: input
 @article{full,
 	title = {Full entry, never queried, but field order changed},
 	author = {1789},
@@ -94,6 +101,7 @@
 	volume = {full},
 }
 
+% BTAC sources: input
 @misc{marked,
 	title = {marked entry is not queried},
 	btacqueried = {2024-07-19},
@@ -101,12 +109,14 @@
 	pages = {1--150},
 }
 
+% BTAC sources: input
 @article{markedbis,
 	title = {marked entry is not queried},
 	btacqueried = {not necessarily a data},
 	doi = {10.22222/123456789},
 }
 
+% BTAC sources: input, fake_lookup
 @misc{all_fields_for_misc,
 	title = {Test for filter-by-entrytype},
 	author = {My Guy},
@@ -124,6 +134,7 @@
 	year = {2015},
 }
 
+% BTAC sources: input, fake_lookup
 @misc{opt_field_for_misc,
 	title = {Test for filter-by-entrytype},
 	author = {My Guy},
@@ -140,6 +151,7 @@
 	year = {2015},
 }
 
+% BTAC sources: input, fake_lookup
 @misc{req_field_for_misc,
 	title = {Test for filter-by-entrytype},
 	author = {{Doe}9, {John}},
@@ -155,6 +167,7 @@
 	volume = {9},
 }
 
+% BTAC sources: input, fake_lookup
 @article{entry0,
 	title = {Title of entry 0},
 	author = {{Doe}10, {John}},
@@ -170,6 +183,7 @@
 	volume = {10},
 }
 
+% BTAC sources: input, fake_lookup
 @book{entry1,
 	title = {Title of entry 1},
 	author = {{Doe}11, {John}},
@@ -185,6 +199,7 @@
 	volume = {11},
 }
 
+% BTAC sources: input, fake_lookup
 @booklet{entry2,
 	title = {Title of entry 2},
 	author = {{Doe}12, {John}},
@@ -200,6 +215,7 @@
 	volume = {12},
 }
 
+% BTAC sources: input, fake_lookup
 @conference{entry3,
 	title = {Title of entry 3},
 	author = {{Doe}13, {John}},
@@ -216,6 +232,7 @@
 	volume = {13},
 }
 
+% BTAC sources: input, fake_lookup
 @inbook{entry4,
 	title = {Title of entry 4},
 	author = {{Doe}14, {John}},
@@ -231,6 +248,7 @@
 	volume = {14},
 }
 
+% BTAC sources: input, fake_lookup
 @incollection{entry5,
 	title = {Title of entry 5},
 	author = {{Doe}15, {John}},
@@ -246,6 +264,7 @@
 	volume = {15},
 }
 
+% BTAC sources: input, fake_lookup
 @manual{entry6,
 	title = {Title of entry 6},
 	author = {{Doe}16, {John}},
@@ -261,6 +280,7 @@
 	volume = {16},
 }
 
+% BTAC sources: input, fake_lookup
 @mastersthesis{entry7,
 	title = {Title of entry 7},
 	author = {{Doe}17, {John}},
@@ -276,6 +296,7 @@
 	volume = {17},
 }
 
+% BTAC sources: input, fake_lookup
 @misc{entry8,
 	title = {Title of entry 8},
 	author = {{Doe}18, {John}},
@@ -291,6 +312,7 @@
 	volume = {18},
 }
 
+% BTAC sources: input, fake_lookup
 @techreport{entry9,
 	title = {Title of entry 9},
 	author = {{Doe}19, {John}},
@@ -306,6 +328,7 @@
 	volume = {19},
 }
 
+% BTAC sources: input, fake_lookup
 @unpublished{entry10,
 	title = {Title of entry 10},
 	author = {{Doe}20, {John}},
@@ -321,6 +344,7 @@
 	volume = {20},
 }
 
+% BTAC sources: input, fake_lookup
 @inproceedings{entry11,
 	title = {Title of entry 11},
 	author = {{Doe}21, {John}},
@@ -336,6 +360,7 @@
 	volume = {21},
 }
 
+% BTAC sources: input, fake_lookup
 @phdthesis{entry12,
 	title = {Title of entry 12},
 	author = {{Doe}22, {John}},
@@ -351,6 +376,7 @@
 	volume = {22},
 }
 
+% BTAC sources: input, fake_lookup
 @misc{with_accents,
 	title = {Lots OF accents AnD Capitalization: éàêïæøçÉÀÊÏÆØÇ},
 	author = {Somebody},

--- a/tests/bibs/format-uppercase.btac.bib.exp
+++ b/tests/bibs/format-uppercase.btac.bib.exp
@@ -3,6 +3,7 @@
 
 @comment{Outside of entries, text is just a comment}
 
+% BTAC sources: input, fake_lookup
 @misc{entry_basic,
 	title = {My awesome article},
 	author = {Yours Truly},
@@ -18,6 +19,7 @@
 	volume = {1},
 }
 
+% BTAC sources: input, fake_lookup
 @article{entry_basic2,
 	title = {Something},
 	author = {Someone},
@@ -34,14 +36,17 @@
 	volume = {2},
 }
 
+% BTAC sources: input
 @booklet{almost_empty,
 	note = {This entry shouldn't be queried, no useful data},
 }
 
+% BTAC sources: input
 @techreport{also_almost_empty,
 	foo = {bar: no standard field at all},
 }
 
+% BTAC sources: input, fake_lookup
 @article{doi,
 	title = {{Generated} title 5},
 	author = {{Doe}5, {John}},
@@ -57,6 +62,7 @@
 	volume = {5},
 }
 
+% BTAC sources: input, fake_lookup
 @inproceedings{giberish,
 	title = {giberish},
 	author = {1789},
@@ -76,6 +82,7 @@
 	volume = {6},
 }
 
+% BTAC sources: input
 @article{full,
 	title = {Full entry, never queried, but field order changed},
 	author = {1789},
@@ -94,6 +101,7 @@
 	volume = {full},
 }
 
+% BTAC sources: input
 @misc{marked,
 	title = {marked entry is not queried},
 	btacqueried = {2024-07-19},
@@ -101,12 +109,14 @@
 	pages = {1--150},
 }
 
+% BTAC sources: input
 @article{markedbis,
 	title = {marked entry is not queried},
 	btacqueried = {not necessarily a data},
 	doi = {10.22222/123456789},
 }
 
+% BTAC sources: input, fake_lookup
 @misc{all_fields_for_misc,
 	title = {Test for filter-by-entrytype},
 	author = {My Guy},
@@ -124,6 +134,7 @@
 	year = {2015},
 }
 
+% BTAC sources: input, fake_lookup
 @misc{opt_field_for_misc,
 	title = {Test for filter-by-entrytype},
 	author = {My Guy},
@@ -140,6 +151,7 @@
 	year = {2015},
 }
 
+% BTAC sources: input, fake_lookup
 @misc{req_field_for_misc,
 	title = {Test for filter-by-entrytype},
 	author = {{Doe}9, {John}},
@@ -155,6 +167,7 @@
 	volume = {9},
 }
 
+% BTAC sources: input, fake_lookup
 @article{entry0,
 	title = {Title of entry 0},
 	author = {{Doe}10, {John}},
@@ -170,6 +183,7 @@
 	volume = {10},
 }
 
+% BTAC sources: input, fake_lookup
 @book{entry1,
 	title = {Title of entry 1},
 	author = {{Doe}11, {John}},
@@ -185,6 +199,7 @@
 	volume = {11},
 }
 
+% BTAC sources: input, fake_lookup
 @booklet{entry2,
 	title = {Title of entry 2},
 	author = {{Doe}12, {John}},
@@ -200,6 +215,7 @@
 	volume = {12},
 }
 
+% BTAC sources: input, fake_lookup
 @conference{entry3,
 	title = {Title of entry 3},
 	author = {{Doe}13, {John}},
@@ -216,6 +232,7 @@
 	volume = {13},
 }
 
+% BTAC sources: input, fake_lookup
 @inbook{entry4,
 	title = {Title of entry 4},
 	author = {{Doe}14, {John}},
@@ -231,6 +248,7 @@
 	volume = {14},
 }
 
+% BTAC sources: input, fake_lookup
 @incollection{entry5,
 	title = {Title of entry 5},
 	author = {{Doe}15, {John}},
@@ -246,6 +264,7 @@
 	volume = {15},
 }
 
+% BTAC sources: input, fake_lookup
 @manual{entry6,
 	title = {Title of entry 6},
 	author = {{Doe}16, {John}},
@@ -261,6 +280,7 @@
 	volume = {16},
 }
 
+% BTAC sources: input, fake_lookup
 @mastersthesis{entry7,
 	title = {Title of entry 7},
 	author = {{Doe}17, {John}},
@@ -276,6 +296,7 @@
 	volume = {17},
 }
 
+% BTAC sources: input, fake_lookup
 @misc{entry8,
 	title = {Title of entry 8},
 	author = {{Doe}18, {John}},
@@ -291,6 +312,7 @@
 	volume = {18},
 }
 
+% BTAC sources: input, fake_lookup
 @techreport{entry9,
 	title = {Title of entry 9},
 	author = {{Doe}19, {John}},
@@ -306,6 +328,7 @@
 	volume = {19},
 }
 
+% BTAC sources: input, fake_lookup
 @unpublished{entry10,
 	title = {Title of entry 10},
 	author = {{Doe}20, {John}},
@@ -321,6 +344,7 @@
 	volume = {20},
 }
 
+% BTAC sources: input, fake_lookup
 @inproceedings{entry11,
 	title = {Title of entry 11},
 	author = {{Doe}21, {John}},
@@ -336,6 +360,7 @@
 	volume = {21},
 }
 
+% BTAC sources: input, fake_lookup
 @phdthesis{entry12,
 	title = {Title of entry 12},
 	author = {{Doe}22, {John}},
@@ -351,6 +376,7 @@
 	volume = {22},
 }
 
+% BTAC sources: input, fake_lookup
 @misc{with_accents,
 	title = {Lots OF accents AnD Capitalization: éàêïæøçÉÀÊÏÆØÇ},
 	author = {Somebody},

--- a/tests/bibs/input.btac.bib.exp
+++ b/tests/bibs/input.btac.bib.exp
@@ -3,6 +3,7 @@
 
 @comment{Outside of entries, text is just a comment}
 
+% BTAC sources: input, fake_lookup
 @misc{entry_basic,
 	title = {My awesome article},
 	author = {Yours Truly},
@@ -18,6 +19,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {1},
 }
 
+% BTAC sources: input, fake_lookup
 @article{entry_basic2,
 	title = {Something},
 	author = {Someone},
@@ -34,14 +36,17 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {2},
 }
 
+% BTAC sources: input
 @booklet{almost_empty,
 	note = {This entry shouldn't be queried, no useful data},
 }
 
+% BTAC sources: input
 @techreport{also_almost_empty,
 	foo = {bar: no standard field at all},
 }
 
+% BTAC sources: input, fake_lookup
 @article{doi,
 	title = {Generated title 5},
 	author = {Doe5, John},
@@ -57,6 +62,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {5},
 }
 
+% BTAC sources: input, fake_lookup
 @inproceedings{giberish,
 	title = {giberish},
 	author = {1789},
@@ -76,6 +82,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {6},
 }
 
+% BTAC sources: input
 @article{full,
 	title = {Full entry, never queried, but field order changed},
 	author = {1789},
@@ -94,6 +101,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {full},
 }
 
+% BTAC sources: input
 @misc{marked,
 	title = {marked entry is not queried},
 	btacqueried = {2024-07-19},
@@ -101,12 +109,14 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	pages = {1--150},
 }
 
+% BTAC sources: input
 @article{markedbis,
 	title = {marked entry is not queried},
 	btacqueried = {not necessarily a data},
 	doi = {10.22222/123456789},
 }
 
+% BTAC sources: input, fake_lookup
 @misc{all_fields_for_misc,
 	title = {Test for filter-by-entrytype},
 	author = {My Guy},
@@ -124,6 +134,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	year = {2015},
 }
 
+% BTAC sources: input, fake_lookup
 @misc{opt_field_for_misc,
 	title = {Test for filter-by-entrytype},
 	author = {My Guy},
@@ -140,6 +151,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	year = {2015},
 }
 
+% BTAC sources: input, fake_lookup
 @misc{req_field_for_misc,
 	title = {Test for filter-by-entrytype},
 	author = {Doe9, John},
@@ -155,6 +167,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {9},
 }
 
+% BTAC sources: input, fake_lookup
 @article{entry0,
 	title = {Title of entry 0},
 	author = {Doe10, John},
@@ -170,6 +183,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {10},
 }
 
+% BTAC sources: input, fake_lookup
 @book{entry1,
 	title = {Title of entry 1},
 	author = {Doe11, John},
@@ -185,6 +199,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {11},
 }
 
+% BTAC sources: input, fake_lookup
 @booklet{entry2,
 	title = {Title of entry 2},
 	author = {Doe12, John},
@@ -200,6 +215,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {12},
 }
 
+% BTAC sources: input, fake_lookup
 @conference{entry3,
 	title = {Title of entry 3},
 	author = {Doe13, John},
@@ -216,6 +232,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {13},
 }
 
+% BTAC sources: input, fake_lookup
 @inbook{entry4,
 	title = {Title of entry 4},
 	author = {Doe14, John},
@@ -231,6 +248,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {14},
 }
 
+% BTAC sources: input, fake_lookup
 @incollection{entry5,
 	title = {Title of entry 5},
 	author = {Doe15, John},
@@ -246,6 +264,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {15},
 }
 
+% BTAC sources: input, fake_lookup
 @manual{entry6,
 	title = {Title of entry 6},
 	author = {Doe16, John},
@@ -261,6 +280,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {16},
 }
 
+% BTAC sources: input, fake_lookup
 @mastersthesis{entry7,
 	title = {Title of entry 7},
 	author = {Doe17, John},
@@ -276,6 +296,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {17},
 }
 
+% BTAC sources: input, fake_lookup
 @misc{entry8,
 	title = {Title of entry 8},
 	author = {Doe18, John},
@@ -291,6 +312,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {18},
 }
 
+% BTAC sources: input, fake_lookup
 @techreport{entry9,
 	title = {Title of entry 9},
 	author = {Doe19, John},
@@ -306,6 +328,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {19},
 }
 
+% BTAC sources: input, fake_lookup
 @unpublished{entry10,
 	title = {Title of entry 10},
 	author = {Doe20, John},
@@ -321,6 +344,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {20},
 }
 
+% BTAC sources: input, fake_lookup
 @inproceedings{entry11,
 	title = {Title of entry 11},
 	author = {Doe21, John},
@@ -336,6 +360,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {21},
 }
 
+% BTAC sources: input, fake_lookup
 @phdthesis{entry12,
 	title = {Title of entry 12},
 	author = {Doe22, John},
@@ -351,6 +376,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {22},
 }
 
+% BTAC sources: input, fake_lookup
 @misc{with_accents,
 	title = {Lots OF accents AnD Capitalization: éàêïæøçÉÀÊÏÆØÇ},
 	author = {Somebody},

--- a/tests/bibs/mark-ignore.btac.bib.exp
+++ b/tests/bibs/mark-ignore.btac.bib.exp
@@ -3,6 +3,7 @@
 
 @comment{Outside of entries, text is just a comment}
 
+% BTAC sources: input, fake_lookup
 @misc{entry_basic,
 	title = {My awesome article},
 	author = {Yours Truly},
@@ -18,6 +19,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {1},
 }
 
+% BTAC sources: input, fake_lookup
 @article{entry_basic2,
 	title = {Something},
 	author = {Someone},
@@ -34,14 +36,17 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {2},
 }
 
+% BTAC sources: input
 @booklet{almost_empty,
 	note = {This entry shouldn't be queried, no useful data},
 }
 
+% BTAC sources: input
 @techreport{also_almost_empty,
 	foo = {bar: no standard field at all},
 }
 
+% BTAC sources: input, fake_lookup
 @article{doi,
 	title = {Generated title 5},
 	author = {Doe5, John},
@@ -57,6 +62,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {5},
 }
 
+% BTAC sources: input, fake_lookup
 @inproceedings{giberish,
 	title = {giberish},
 	author = {1789},
@@ -76,6 +82,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {6},
 }
 
+% BTAC sources: input
 @article{full,
 	title = {Full entry, never queried, but field order changed},
 	author = {1789},
@@ -94,6 +101,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {full},
 }
 
+% BTAC sources: input, fake_lookup
 @misc{marked,
 	title = {marked entry is not queried},
 	author = {Doe7, John},
@@ -110,6 +118,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {7},
 }
 
+% BTAC sources: input, fake_lookup
 @article{markedbis,
 	title = {marked entry is not queried},
 	author = {Doe8, John},
@@ -126,6 +135,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {8},
 }
 
+% BTAC sources: input, fake_lookup
 @misc{all_fields_for_misc,
 	title = {Test for filter-by-entrytype},
 	author = {My Guy},
@@ -143,6 +153,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	year = {2015},
 }
 
+% BTAC sources: input, fake_lookup
 @misc{opt_field_for_misc,
 	title = {Test for filter-by-entrytype},
 	author = {My Guy},
@@ -159,6 +170,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	year = {2015},
 }
 
+% BTAC sources: input, fake_lookup
 @misc{req_field_for_misc,
 	title = {Test for filter-by-entrytype},
 	author = {Doe11, John},
@@ -174,6 +186,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {11},
 }
 
+% BTAC sources: input, fake_lookup
 @article{entry0,
 	title = {Title of entry 0},
 	author = {Doe12, John},
@@ -189,6 +202,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {12},
 }
 
+% BTAC sources: input, fake_lookup
 @book{entry1,
 	title = {Title of entry 1},
 	author = {Doe13, John},
@@ -205,6 +219,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {13},
 }
 
+% BTAC sources: input, fake_lookup
 @booklet{entry2,
 	title = {Title of entry 2},
 	author = {Doe14, John},
@@ -220,6 +235,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {14},
 }
 
+% BTAC sources: input, fake_lookup
 @conference{entry3,
 	title = {Title of entry 3},
 	author = {Doe15, John},
@@ -235,6 +251,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {15},
 }
 
+% BTAC sources: input, fake_lookup
 @inbook{entry4,
 	title = {Title of entry 4},
 	author = {Doe16, John},
@@ -250,6 +267,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {16},
 }
 
+% BTAC sources: input, fake_lookup
 @incollection{entry5,
 	title = {Title of entry 5},
 	author = {Doe17, John},
@@ -265,6 +283,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {17},
 }
 
+% BTAC sources: input, fake_lookup
 @manual{entry6,
 	title = {Title of entry 6},
 	author = {Doe18, John},
@@ -280,6 +299,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {18},
 }
 
+% BTAC sources: input, fake_lookup
 @mastersthesis{entry7,
 	title = {Title of entry 7},
 	author = {Doe19, John},
@@ -295,6 +315,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {19},
 }
 
+% BTAC sources: input, fake_lookup
 @misc{entry8,
 	title = {Title of entry 8},
 	author = {Doe20, John},
@@ -310,6 +331,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {20},
 }
 
+% BTAC sources: input, fake_lookup
 @techreport{entry9,
 	title = {Title of entry 9},
 	author = {Doe21, John},
@@ -325,6 +347,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {21},
 }
 
+% BTAC sources: input, fake_lookup
 @unpublished{entry10,
 	title = {Title of entry 10},
 	author = {Doe22, John},
@@ -340,6 +363,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {22},
 }
 
+% BTAC sources: input, fake_lookup
 @inproceedings{entry11,
 	title = {Title of entry 11},
 	author = {Doe23, John},
@@ -355,6 +379,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {23},
 }
 
+% BTAC sources: input, fake_lookup
 @phdthesis{entry12,
 	title = {Title of entry 12},
 	author = {Doe24, John},
@@ -371,6 +396,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {24},
 }
 
+% BTAC sources: input, fake_lookup
 @misc{with_accents,
 	title = {Lots OF accents AnD Capitalization: éàêïæøçÉÀÊÏÆØÇ},
 	author = {Somebody},

--- a/tests/bibs/mark-prefix.btac.bib.exp
+++ b/tests/bibs/mark-prefix.btac.bib.exp
@@ -3,6 +3,7 @@
 
 @comment{Outside of entries, text is just a comment}
 
+% BTAC sources: input, fake_lookup
 @misc{entry_basic,
 	title = {My awesome article},
 	author = {Yours Truly},
@@ -19,6 +20,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	BTACvolume = {1},
 }
 
+% BTAC sources: input, fake_lookup
 @article{entry_basic2,
 	title = {Something},
 	author = {Someone},
@@ -36,16 +38,19 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	BTACvolume = {2},
 }
 
+% BTAC sources: input
 @booklet{almost_empty,
 	BTACqueried = {DATE},
 	note = {This entry shouldn't be queried, no useful data},
 }
 
+% BTAC sources: input
 @techreport{also_almost_empty,
 	BTACqueried = {DATE},
 	foo = {bar: no standard field at all},
 }
 
+% BTAC sources: input, fake_lookup
 @article{doi,
 	BTACauthor = {Doe5, John},
 	BTACbooktitle = {Generated booktitle 5},
@@ -62,6 +67,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	doi = {10.5432/hello},
 }
 
+% BTAC sources: input, fake_lookup
 @inproceedings{giberish,
 	title = {giberish},
 	author = {1789},
@@ -82,6 +88,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	pages = {not a number},
 }
 
+% BTAC sources: input
 @article{full,
 	title = {Full entry, never queried, but field order changed},
 	author = {1789},
@@ -101,6 +108,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {full},
 }
 
+% BTAC sources: input
 @misc{marked,
 	title = {marked entry is not queried},
 	btacqueried = {2024-07-19},
@@ -108,12 +116,14 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	pages = {1--150},
 }
 
+% BTAC sources: input
 @article{markedbis,
 	title = {marked entry is not queried},
 	btacqueried = {not necessarily a data},
 	doi = {10.22222/123456789},
 }
 
+% BTAC sources: input, fake_lookup
 @misc{all_fields_for_misc,
 	title = {Test for filter-by-entrytype},
 	author = {My Guy},
@@ -132,6 +142,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	year = {2015},
 }
 
+% BTAC sources: input, fake_lookup
 @misc{opt_field_for_misc,
 	title = {Test for filter-by-entrytype},
 	author = {My Guy},
@@ -149,6 +160,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	year = {2015},
 }
 
+% BTAC sources: input, fake_lookup
 @misc{req_field_for_misc,
 	title = {Test for filter-by-entrytype},
 	BTACauthor = {Doe9, John},
@@ -165,6 +177,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	BTACvolume = {9},
 }
 
+% BTAC sources: input, fake_lookup
 @article{entry0,
 	title = {Title of entry 0},
 	BTACauthor = {Doe10, John},
@@ -181,6 +194,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	BTACvolume = {10},
 }
 
+% BTAC sources: input, fake_lookup
 @book{entry1,
 	title = {Title of entry 1},
 	BTACauthor = {Doe11, John},
@@ -197,6 +211,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	BTACvolume = {11},
 }
 
+% BTAC sources: input, fake_lookup
 @booklet{entry2,
 	title = {Title of entry 2},
 	BTACauthor = {Doe12, John},
@@ -213,6 +228,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	BTACvolume = {12},
 }
 
+% BTAC sources: input, fake_lookup
 @conference{entry3,
 	title = {Title of entry 3},
 	BTACauthor = {Doe13, John},
@@ -230,6 +246,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	BTACvolume = {13},
 }
 
+% BTAC sources: input, fake_lookup
 @inbook{entry4,
 	title = {Title of entry 4},
 	BTACauthor = {Doe14, John},
@@ -246,6 +263,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	BTACvolume = {14},
 }
 
+% BTAC sources: input, fake_lookup
 @incollection{entry5,
 	title = {Title of entry 5},
 	BTACauthor = {Doe15, John},
@@ -262,6 +280,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	BTACvolume = {15},
 }
 
+% BTAC sources: input, fake_lookup
 @manual{entry6,
 	title = {Title of entry 6},
 	BTACauthor = {Doe16, John},
@@ -278,6 +297,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	BTACvolume = {16},
 }
 
+% BTAC sources: input, fake_lookup
 @mastersthesis{entry7,
 	title = {Title of entry 7},
 	BTACauthor = {Doe17, John},
@@ -294,6 +314,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	BTACvolume = {17},
 }
 
+% BTAC sources: input, fake_lookup
 @misc{entry8,
 	title = {Title of entry 8},
 	BTACauthor = {Doe18, John},
@@ -310,6 +331,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	BTACvolume = {18},
 }
 
+% BTAC sources: input, fake_lookup
 @techreport{entry9,
 	title = {Title of entry 9},
 	BTACauthor = {Doe19, John},
@@ -326,6 +348,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	BTACvolume = {19},
 }
 
+% BTAC sources: input, fake_lookup
 @unpublished{entry10,
 	title = {Title of entry 10},
 	BTACauthor = {Doe20, John},
@@ -342,6 +365,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	BTACvolume = {20},
 }
 
+% BTAC sources: input, fake_lookup
 @inproceedings{entry11,
 	title = {Title of entry 11},
 	BTACauthor = {Doe21, John},
@@ -358,6 +382,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	BTACvolume = {21},
 }
 
+% BTAC sources: input, fake_lookup
 @phdthesis{entry12,
 	title = {Title of entry 12},
 	BTACauthor = {Doe22, John},
@@ -374,6 +399,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	BTACvolume = {22},
 }
 
+% BTAC sources: input, fake_lookup
 @misc{with_accents,
 	title = {Lots OF accents AnD Capitalization: éàêïæøçÉÀÊÏÆØÇ},
 	author = {Somebody},

--- a/tests/bibs/mark.btac.bib.exp
+++ b/tests/bibs/mark.btac.bib.exp
@@ -3,6 +3,7 @@
 
 @comment{Outside of entries, text is just a comment}
 
+% BTAC sources: input, fake_lookup
 @misc{entry_basic,
 	title = {My awesome article},
 	author = {Yours Truly},
@@ -19,6 +20,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {1},
 }
 
+% BTAC sources: input, fake_lookup
 @article{entry_basic2,
 	title = {Something},
 	author = {Someone},
@@ -36,16 +38,19 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {2},
 }
 
+% BTAC sources: input
 @booklet{almost_empty,
 	BTACqueried = {DATE},
 	note = {This entry shouldn't be queried, no useful data},
 }
 
+% BTAC sources: input
 @techreport{also_almost_empty,
 	BTACqueried = {DATE},
 	foo = {bar: no standard field at all},
 }
 
+% BTAC sources: input, fake_lookup
 @article{doi,
 	title = {Generated title 5},
 	author = {Doe5, John},
@@ -62,6 +67,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {5},
 }
 
+% BTAC sources: input, fake_lookup
 @inproceedings{giberish,
 	title = {giberish},
 	author = {1789},
@@ -82,6 +88,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {6},
 }
 
+% BTAC sources: input
 @article{full,
 	title = {Full entry, never queried, but field order changed},
 	author = {1789},
@@ -101,6 +108,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {full},
 }
 
+% BTAC sources: input
 @misc{marked,
 	title = {marked entry is not queried},
 	btacqueried = {2024-07-19},
@@ -108,12 +116,14 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	pages = {1--150},
 }
 
+% BTAC sources: input
 @article{markedbis,
 	title = {marked entry is not queried},
 	btacqueried = {not necessarily a data},
 	doi = {10.22222/123456789},
 }
 
+% BTAC sources: input, fake_lookup
 @misc{all_fields_for_misc,
 	title = {Test for filter-by-entrytype},
 	author = {My Guy},
@@ -132,6 +142,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	year = {2015},
 }
 
+% BTAC sources: input, fake_lookup
 @misc{opt_field_for_misc,
 	title = {Test for filter-by-entrytype},
 	author = {My Guy},
@@ -149,6 +160,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	year = {2015},
 }
 
+% BTAC sources: input, fake_lookup
 @misc{req_field_for_misc,
 	title = {Test for filter-by-entrytype},
 	author = {Doe9, John},
@@ -165,6 +177,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {9},
 }
 
+% BTAC sources: input, fake_lookup
 @article{entry0,
 	title = {Title of entry 0},
 	author = {Doe10, John},
@@ -181,6 +194,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {10},
 }
 
+% BTAC sources: input, fake_lookup
 @book{entry1,
 	title = {Title of entry 1},
 	author = {Doe11, John},
@@ -197,6 +211,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {11},
 }
 
+% BTAC sources: input, fake_lookup
 @booklet{entry2,
 	title = {Title of entry 2},
 	author = {Doe12, John},
@@ -213,6 +228,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {12},
 }
 
+% BTAC sources: input, fake_lookup
 @conference{entry3,
 	title = {Title of entry 3},
 	author = {Doe13, John},
@@ -230,6 +246,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {13},
 }
 
+% BTAC sources: input, fake_lookup
 @inbook{entry4,
 	title = {Title of entry 4},
 	author = {Doe14, John},
@@ -246,6 +263,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {14},
 }
 
+% BTAC sources: input, fake_lookup
 @incollection{entry5,
 	title = {Title of entry 5},
 	author = {Doe15, John},
@@ -262,6 +280,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {15},
 }
 
+% BTAC sources: input, fake_lookup
 @manual{entry6,
 	title = {Title of entry 6},
 	author = {Doe16, John},
@@ -278,6 +297,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {16},
 }
 
+% BTAC sources: input, fake_lookup
 @mastersthesis{entry7,
 	title = {Title of entry 7},
 	author = {Doe17, John},
@@ -294,6 +314,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {17},
 }
 
+% BTAC sources: input, fake_lookup
 @misc{entry8,
 	title = {Title of entry 8},
 	author = {Doe18, John},
@@ -310,6 +331,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {18},
 }
 
+% BTAC sources: input, fake_lookup
 @techreport{entry9,
 	title = {Title of entry 9},
 	author = {Doe19, John},
@@ -326,6 +348,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {19},
 }
 
+% BTAC sources: input, fake_lookup
 @unpublished{entry10,
 	title = {Title of entry 10},
 	author = {Doe20, John},
@@ -342,6 +365,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {20},
 }
 
+% BTAC sources: input, fake_lookup
 @inproceedings{entry11,
 	title = {Title of entry 11},
 	author = {Doe21, John},
@@ -358,6 +382,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {21},
 }
 
+% BTAC sources: input, fake_lookup
 @phdthesis{entry12,
 	title = {Title of entry 12},
 	author = {Doe22, John},
@@ -374,6 +399,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {22},
 }
 
+% BTAC sources: input, fake_lookup
 @misc{with_accents,
 	title = {Lots OF accents AnD Capitalization: éàêïæøçÉÀÊÏÆØÇ},
 	author = {Somebody},

--- a/tests/bibs/overwrite-prefix.btac.bib.exp
+++ b/tests/bibs/overwrite-prefix.btac.bib.exp
@@ -3,6 +3,7 @@
 
 @comment{Outside of entries, text is just a comment}
 
+% BTAC sources: input, fake_lookup
 @misc{entry_basic,
 	title = {My awesome article},
 	author = {Yours Truly},
@@ -20,6 +21,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	BTACvolume = {1},
 }
 
+% BTAC sources: input, fake_lookup
 @article{entry_basic2,
 	title = {Something},
 	author = {Someone},
@@ -38,14 +40,17 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	BTACvolume = {2},
 }
 
+% BTAC sources: input
 @booklet{almost_empty,
 	note = {This entry shouldn't be queried, no useful data},
 }
 
+% BTAC sources: input
 @techreport{also_almost_empty,
 	foo = {bar: no standard field at all},
 }
 
+% BTAC sources: input, fake_lookup
 @article{doi,
 	BTACauthor = {Doe5, John},
 	BTACbooktitle = {Generated booktitle 5},
@@ -62,6 +67,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	doi = {10.5432/hello},
 }
 
+% BTAC sources: input, fake_lookup
 @inproceedings{giberish,
 	title = {giberish},
 	author = {1789},
@@ -85,6 +91,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	pages = {not a number},
 }
 
+% BTAC sources: input, fake_lookup
 @article{full,
 	title = {Full entry, never queried, but field order changed},
 	author = {1789},
@@ -114,6 +121,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {full},
 }
 
+% BTAC sources: input
 @misc{marked,
 	title = {marked entry is not queried},
 	btacqueried = {2024-07-19},
@@ -121,12 +129,14 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	pages = {1--150},
 }
 
+% BTAC sources: input
 @article{markedbis,
 	title = {marked entry is not queried},
 	btacqueried = {not necessarily a data},
 	doi = {10.22222/123456789},
 }
 
+% BTAC sources: input, fake_lookup
 @misc{all_fields_for_misc,
 	title = {Test for filter-by-entrytype},
 	author = {My Guy},
@@ -150,6 +160,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	year = {2015},
 }
 
+% BTAC sources: input, fake_lookup
 @misc{opt_field_for_misc,
 	title = {Test for filter-by-entrytype},
 	author = {My Guy},
@@ -172,6 +183,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	year = {2015},
 }
 
+% BTAC sources: input, fake_lookup
 @misc{req_field_for_misc,
 	title = {Test for filter-by-entrytype},
 	BTACauthor = {Doe10, John},
@@ -188,6 +200,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	BTACvolume = {10},
 }
 
+% BTAC sources: input, fake_lookup
 @article{entry0,
 	title = {Title of entry 0},
 	BTACauthor = {Doe11, John},
@@ -204,6 +217,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	BTACvolume = {11},
 }
 
+% BTAC sources: input, fake_lookup
 @book{entry1,
 	title = {Title of entry 1},
 	BTACauthor = {Doe12, John},
@@ -220,6 +234,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	BTACvolume = {12},
 }
 
+% BTAC sources: input, fake_lookup
 @booklet{entry2,
 	title = {Title of entry 2},
 	BTACauthor = {Doe13, John},
@@ -237,6 +252,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	BTACvolume = {13},
 }
 
+% BTAC sources: input, fake_lookup
 @conference{entry3,
 	title = {Title of entry 3},
 	BTACauthor = {Doe14, John},
@@ -253,6 +269,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	BTACvolume = {14},
 }
 
+% BTAC sources: input, fake_lookup
 @inbook{entry4,
 	title = {Title of entry 4},
 	BTACauthor = {Doe15, John},
@@ -269,6 +286,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	BTACvolume = {15},
 }
 
+% BTAC sources: input, fake_lookup
 @incollection{entry5,
 	title = {Title of entry 5},
 	BTACauthor = {Doe16, John},
@@ -285,6 +303,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	BTACvolume = {16},
 }
 
+% BTAC sources: input, fake_lookup
 @manual{entry6,
 	title = {Title of entry 6},
 	BTACauthor = {Doe17, John},
@@ -301,6 +320,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	BTACvolume = {17},
 }
 
+% BTAC sources: input, fake_lookup
 @mastersthesis{entry7,
 	title = {Title of entry 7},
 	BTACauthor = {Doe18, John},
@@ -317,6 +337,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	BTACvolume = {18},
 }
 
+% BTAC sources: input, fake_lookup
 @misc{entry8,
 	title = {Title of entry 8},
 	BTACauthor = {Doe19, John},
@@ -333,6 +354,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	BTACvolume = {19},
 }
 
+% BTAC sources: input, fake_lookup
 @techreport{entry9,
 	title = {Title of entry 9},
 	BTACauthor = {Doe20, John},
@@ -349,6 +371,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	BTACvolume = {20},
 }
 
+% BTAC sources: input, fake_lookup
 @unpublished{entry10,
 	title = {Title of entry 10},
 	BTACauthor = {Doe21, John},
@@ -365,6 +388,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	BTACvolume = {21},
 }
 
+% BTAC sources: input, fake_lookup
 @inproceedings{entry11,
 	title = {Title of entry 11},
 	BTACauthor = {Doe22, John},
@@ -381,6 +405,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	BTACvolume = {22},
 }
 
+% BTAC sources: input, fake_lookup
 @phdthesis{entry12,
 	title = {Title of entry 12},
 	BTACauthor = {Doe23, John},
@@ -397,6 +422,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	BTACvolume = {23},
 }
 
+% BTAC sources: input, fake_lookup
 @misc{with_accents,
 	title = {Lots OF accents AnD Capitalization: éàêïæøçÉÀÊÏÆØÇ},
 	author = {Somebody},

--- a/tests/bibs/overwrite-selection-prefix.btac.bib.exp
+++ b/tests/bibs/overwrite-selection-prefix.btac.bib.exp
@@ -3,6 +3,7 @@
 
 @comment{Outside of entries, text is just a comment}
 
+% BTAC sources: input, fake_lookup
 @misc{entry_basic,
 	title = {My awesome article},
 	author = {Yours Truly},
@@ -19,6 +20,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	BTACvolume = {1},
 }
 
+% BTAC sources: input, fake_lookup
 @article{entry_basic2,
 	title = {Something},
 	author = {Someone},
@@ -36,14 +38,17 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	BTACvolume = {2},
 }
 
+% BTAC sources: input
 @booklet{almost_empty,
 	note = {This entry shouldn't be queried, no useful data},
 }
 
+% BTAC sources: input
 @techreport{also_almost_empty,
 	foo = {bar: no standard field at all},
 }
 
+% BTAC sources: input, fake_lookup
 @article{doi,
 	BTACauthor = {Doe5, John},
 	BTACbooktitle = {Generated booktitle 5},
@@ -60,6 +65,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	doi = {10.5432/hello},
 }
 
+% BTAC sources: input, fake_lookup
 @inproceedings{giberish,
 	title = {giberish},
 	author = {1789},
@@ -82,6 +88,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	pages = {not a number},
 }
 
+% BTAC sources: input, fake_lookup
 @article{full,
 	title = {Full entry, never queried, but field order changed},
 	author = {1789},
@@ -110,6 +117,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {full},
 }
 
+% BTAC sources: input
 @misc{marked,
 	title = {marked entry is not queried},
 	btacqueried = {2024-07-19},
@@ -117,12 +125,14 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	pages = {1--150},
 }
 
+% BTAC sources: input
 @article{markedbis,
 	title = {marked entry is not queried},
 	btacqueried = {not necessarily a data},
 	doi = {10.22222/123456789},
 }
 
+% BTAC sources: input, fake_lookup
 @misc{all_fields_for_misc,
 	title = {Test for filter-by-entrytype},
 	author = {My Guy},
@@ -143,6 +153,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	year = {2015},
 }
 
+% BTAC sources: input, fake_lookup
 @misc{opt_field_for_misc,
 	title = {Test for filter-by-entrytype},
 	author = {My Guy},
@@ -162,6 +173,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	year = {2015},
 }
 
+% BTAC sources: input, fake_lookup
 @misc{req_field_for_misc,
 	title = {Test for filter-by-entrytype},
 	BTACauthor = {Doe10, John},
@@ -178,6 +190,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	BTACvolume = {10},
 }
 
+% BTAC sources: input, fake_lookup
 @article{entry0,
 	title = {Title of entry 0},
 	BTACauthor = {Doe11, John},
@@ -194,6 +207,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	BTACvolume = {11},
 }
 
+% BTAC sources: input, fake_lookup
 @book{entry1,
 	title = {Title of entry 1},
 	BTACauthor = {Doe12, John},
@@ -210,6 +224,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	BTACvolume = {12},
 }
 
+% BTAC sources: input, fake_lookup
 @booklet{entry2,
 	title = {Title of entry 2},
 	BTACauthor = {Doe13, John},
@@ -227,6 +242,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	BTACvolume = {13},
 }
 
+% BTAC sources: input, fake_lookup
 @conference{entry3,
 	title = {Title of entry 3},
 	BTACauthor = {Doe14, John},
@@ -243,6 +259,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	BTACvolume = {14},
 }
 
+% BTAC sources: input, fake_lookup
 @inbook{entry4,
 	title = {Title of entry 4},
 	BTACauthor = {Doe15, John},
@@ -259,6 +276,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	BTACvolume = {15},
 }
 
+% BTAC sources: input, fake_lookup
 @incollection{entry5,
 	title = {Title of entry 5},
 	BTACauthor = {Doe16, John},
@@ -275,6 +293,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	BTACvolume = {16},
 }
 
+% BTAC sources: input, fake_lookup
 @manual{entry6,
 	title = {Title of entry 6},
 	BTACauthor = {Doe17, John},
@@ -291,6 +310,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	BTACvolume = {17},
 }
 
+% BTAC sources: input, fake_lookup
 @mastersthesis{entry7,
 	title = {Title of entry 7},
 	BTACauthor = {Doe18, John},
@@ -307,6 +327,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	BTACvolume = {18},
 }
 
+% BTAC sources: input, fake_lookup
 @misc{entry8,
 	title = {Title of entry 8},
 	BTACauthor = {Doe19, John},
@@ -323,6 +344,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	BTACvolume = {19},
 }
 
+% BTAC sources: input, fake_lookup
 @techreport{entry9,
 	title = {Title of entry 9},
 	BTACauthor = {Doe20, John},
@@ -339,6 +361,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	BTACvolume = {20},
 }
 
+% BTAC sources: input, fake_lookup
 @unpublished{entry10,
 	title = {Title of entry 10},
 	BTACauthor = {Doe21, John},
@@ -355,6 +378,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	BTACvolume = {21},
 }
 
+% BTAC sources: input, fake_lookup
 @inproceedings{entry11,
 	title = {Title of entry 11},
 	BTACauthor = {Doe22, John},
@@ -371,6 +395,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	BTACvolume = {22},
 }
 
+% BTAC sources: input, fake_lookup
 @phdthesis{entry12,
 	title = {Title of entry 12},
 	BTACauthor = {Doe23, John},
@@ -387,6 +412,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	BTACvolume = {23},
 }
 
+% BTAC sources: input, fake_lookup
 @misc{with_accents,
 	title = {Lots OF accents AnD Capitalization: éàêïæøçÉÀÊÏÆØÇ},
 	author = {Somebody},

--- a/tests/bibs/overwrite-selection.btac.bib.exp
+++ b/tests/bibs/overwrite-selection.btac.bib.exp
@@ -3,6 +3,7 @@
 
 @comment{Outside of entries, text is just a comment}
 
+% BTAC sources: input, fake_lookup
 @misc{entry_basic,
 	title = {My awesome article},
 	author = {Yours Truly},
@@ -18,6 +19,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {1},
 }
 
+% BTAC sources: input, fake_lookup
 @article{entry_basic2,
 	title = {Something},
 	author = {Someone},
@@ -34,14 +36,17 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {2},
 }
 
+% BTAC sources: input
 @booklet{almost_empty,
 	note = {This entry shouldn't be queried, no useful data},
 }
 
+% BTAC sources: input
 @techreport{also_almost_empty,
 	foo = {bar: no standard field at all},
 }
 
+% BTAC sources: input, fake_lookup
 @article{doi,
 	title = {Generated title 5},
 	author = {Doe5, John},
@@ -57,6 +62,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {5},
 }
 
+% BTAC sources: input, fake_lookup
 @inproceedings{giberish,
 	title = {giberish},
 	author = {1789},
@@ -76,6 +82,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {6},
 }
 
+% BTAC sources: input, fake_lookup
 @article{full,
 	title = {Full entry, never queried, but field order changed},
 	author = {1789},
@@ -94,6 +101,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {full},
 }
 
+% BTAC sources: input
 @misc{marked,
 	title = {marked entry is not queried},
 	btacqueried = {2024-07-19},
@@ -101,12 +109,14 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	pages = {1--150},
 }
 
+% BTAC sources: input
 @article{markedbis,
 	title = {marked entry is not queried},
 	btacqueried = {not necessarily a data},
 	doi = {10.22222/123456789},
 }
 
+% BTAC sources: input, fake_lookup
 @misc{all_fields_for_misc,
 	title = {Test for filter-by-entrytype},
 	author = {My Guy},
@@ -123,6 +133,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	year = {2015},
 }
 
+% BTAC sources: input, fake_lookup
 @misc{opt_field_for_misc,
 	title = {Test for filter-by-entrytype},
 	author = {My Guy},
@@ -139,6 +150,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	year = {2015},
 }
 
+% BTAC sources: input, fake_lookup
 @misc{req_field_for_misc,
 	title = {Test for filter-by-entrytype},
 	author = {Doe10, John},
@@ -154,6 +166,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {10},
 }
 
+% BTAC sources: input, fake_lookup
 @article{entry0,
 	title = {Title of entry 0},
 	author = {Doe11, John},
@@ -169,6 +182,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {11},
 }
 
+% BTAC sources: input, fake_lookup
 @book{entry1,
 	title = {Title of entry 1},
 	author = {Doe12, John},
@@ -184,6 +198,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {12},
 }
 
+% BTAC sources: input, fake_lookup
 @booklet{entry2,
 	title = {Title of entry 2},
 	author = {Doe13, John},
@@ -200,6 +215,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {13},
 }
 
+% BTAC sources: input, fake_lookup
 @conference{entry3,
 	title = {Title of entry 3},
 	author = {Doe14, John},
@@ -215,6 +231,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {14},
 }
 
+% BTAC sources: input, fake_lookup
 @inbook{entry4,
 	title = {Title of entry 4},
 	author = {Doe15, John},
@@ -230,6 +247,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {15},
 }
 
+% BTAC sources: input, fake_lookup
 @incollection{entry5,
 	title = {Title of entry 5},
 	author = {Doe16, John},
@@ -245,6 +263,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {16},
 }
 
+% BTAC sources: input, fake_lookup
 @manual{entry6,
 	title = {Title of entry 6},
 	author = {Doe17, John},
@@ -260,6 +279,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {17},
 }
 
+% BTAC sources: input, fake_lookup
 @mastersthesis{entry7,
 	title = {Title of entry 7},
 	author = {Doe18, John},
@@ -275,6 +295,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {18},
 }
 
+% BTAC sources: input, fake_lookup
 @misc{entry8,
 	title = {Title of entry 8},
 	author = {Doe19, John},
@@ -290,6 +311,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {19},
 }
 
+% BTAC sources: input, fake_lookup
 @techreport{entry9,
 	title = {Title of entry 9},
 	author = {Doe20, John},
@@ -305,6 +327,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {20},
 }
 
+% BTAC sources: input, fake_lookup
 @unpublished{entry10,
 	title = {Title of entry 10},
 	author = {Doe21, John},
@@ -320,6 +343,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {21},
 }
 
+% BTAC sources: input, fake_lookup
 @inproceedings{entry11,
 	title = {Title of entry 11},
 	author = {Doe22, John},
@@ -335,6 +359,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {22},
 }
 
+% BTAC sources: input, fake_lookup
 @phdthesis{entry12,
 	title = {Title of entry 12},
 	author = {Doe23, John},
@@ -350,6 +375,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {23},
 }
 
+% BTAC sources: input, fake_lookup
 @misc{with_accents,
 	title = {Lots OF accents AnD Capitalization: éàêïæøçÉÀÊÏÆØÇ},
 	author = {Somebody},

--- a/tests/bibs/overwrite.btac.bib.exp
+++ b/tests/bibs/overwrite.btac.bib.exp
@@ -3,6 +3,7 @@
 
 @comment{Outside of entries, text is just a comment}
 
+% BTAC sources: input, fake_lookup
 @misc{entry_basic,
 	title = {My awesome article},
 	author = {Truly, Yours},
@@ -18,6 +19,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {1},
 }
 
+% BTAC sources: input, fake_lookup
 @article{entry_basic2,
 	title = {Something},
 	author = {Someone},
@@ -34,14 +36,17 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {2},
 }
 
+% BTAC sources: input
 @booklet{almost_empty,
 	note = {This entry shouldn't be queried, no useful data},
 }
 
+% BTAC sources: input
 @techreport{also_almost_empty,
 	foo = {bar: no standard field at all},
 }
 
+% BTAC sources: input, fake_lookup
 @article{doi,
 	title = {Generated title 5},
 	author = {Doe5, John},
@@ -57,6 +62,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {5},
 }
 
+% BTAC sources: input, fake_lookup
 @inproceedings{giberish,
 	title = {giberish},
 	author = {Doe6, John},
@@ -76,6 +82,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {6},
 }
 
+% BTAC sources: input, fake_lookup
 @article{full,
 	title = {Full entry, never queried, but field order changed},
 	author = {Doe7, John},
@@ -94,6 +101,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {full},
 }
 
+% BTAC sources: input
 @misc{marked,
 	title = {marked entry is not queried},
 	btacqueried = {2024-07-19},
@@ -101,12 +109,14 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	pages = {1--150},
 }
 
+% BTAC sources: input
 @article{markedbis,
 	title = {marked entry is not queried},
 	btacqueried = {not necessarily a data},
 	doi = {10.22222/123456789},
 }
 
+% BTAC sources: input, fake_lookup
 @misc{all_fields_for_misc,
 	title = {Test for filter-by-entrytype},
 	author = {Guy, My},
@@ -123,6 +133,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	year = {2015},
 }
 
+% BTAC sources: input, fake_lookup
 @misc{opt_field_for_misc,
 	title = {Test for filter-by-entrytype},
 	author = {Guy, My},
@@ -139,6 +150,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	year = {2015},
 }
 
+% BTAC sources: input, fake_lookup
 @misc{req_field_for_misc,
 	title = {Test for filter-by-entrytype},
 	author = {Doe10, John},
@@ -154,6 +166,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {10},
 }
 
+% BTAC sources: input, fake_lookup
 @article{entry0,
 	title = {Title of entry 0},
 	author = {Doe11, John},
@@ -169,6 +182,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {11},
 }
 
+% BTAC sources: input, fake_lookup
 @book{entry1,
 	title = {Title of entry 1},
 	author = {Doe12, John},
@@ -184,6 +198,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {12},
 }
 
+% BTAC sources: input, fake_lookup
 @booklet{entry2,
 	title = {Title of entry 2},
 	author = {Doe13, John},
@@ -200,6 +215,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {13},
 }
 
+% BTAC sources: input, fake_lookup
 @conference{entry3,
 	title = {Title of entry 3},
 	author = {Doe14, John},
@@ -215,6 +231,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {14},
 }
 
+% BTAC sources: input, fake_lookup
 @inbook{entry4,
 	title = {Title of entry 4},
 	author = {Doe15, John},
@@ -230,6 +247,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {15},
 }
 
+% BTAC sources: input, fake_lookup
 @incollection{entry5,
 	title = {Title of entry 5},
 	author = {Doe16, John},
@@ -245,6 +263,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {16},
 }
 
+% BTAC sources: input, fake_lookup
 @manual{entry6,
 	title = {Title of entry 6},
 	author = {Doe17, John},
@@ -260,6 +279,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {17},
 }
 
+% BTAC sources: input, fake_lookup
 @mastersthesis{entry7,
 	title = {Title of entry 7},
 	author = {Doe18, John},
@@ -275,6 +295,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {18},
 }
 
+% BTAC sources: input, fake_lookup
 @misc{entry8,
 	title = {Title of entry 8},
 	author = {Doe19, John},
@@ -290,6 +311,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {19},
 }
 
+% BTAC sources: input, fake_lookup
 @techreport{entry9,
 	title = {Title of entry 9},
 	author = {Doe20, John},
@@ -305,6 +327,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {20},
 }
 
+% BTAC sources: input, fake_lookup
 @unpublished{entry10,
 	title = {Title of entry 10},
 	author = {Doe21, John},
@@ -320,6 +343,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {21},
 }
 
+% BTAC sources: input, fake_lookup
 @inproceedings{entry11,
 	title = {Title of entry 11},
 	author = {Doe22, John},
@@ -335,6 +359,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {22},
 }
 
+% BTAC sources: input, fake_lookup
 @phdthesis{entry12,
 	title = {Title of entry 12},
 	author = {Doe23, John},
@@ -350,6 +375,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {23},
 }
 
+% BTAC sources: input, fake_lookup
 @misc{with_accents,
 	title = {Lots OF accents AnD Capitalization: éàêïæøçÉÀÊÏÆØÇ},
 	author = {Somebody},

--- a/tests/bibs/prefix.btac.bib.exp
+++ b/tests/bibs/prefix.btac.bib.exp
@@ -3,6 +3,7 @@
 
 @comment{Outside of entries, text is just a comment}
 
+% BTAC sources: input, fake_lookup
 @misc{entry_basic,
 	title = {My awesome article},
 	author = {Yours Truly},
@@ -18,6 +19,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	BTACvolume = {1},
 }
 
+% BTAC sources: input, fake_lookup
 @article{entry_basic2,
 	title = {Something},
 	author = {Someone},
@@ -34,14 +36,17 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	BTACvolume = {2},
 }
 
+% BTAC sources: input
 @booklet{almost_empty,
 	note = {This entry shouldn't be queried, no useful data},
 }
 
+% BTAC sources: input
 @techreport{also_almost_empty,
 	foo = {bar: no standard field at all},
 }
 
+% BTAC sources: input, fake_lookup
 @article{doi,
 	BTACauthor = {Doe5, John},
 	BTACbooktitle = {Generated booktitle 5},
@@ -57,6 +62,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	doi = {10.5432/hello},
 }
 
+% BTAC sources: input, fake_lookup
 @inproceedings{giberish,
 	title = {giberish},
 	author = {1789},
@@ -76,6 +82,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	pages = {not a number},
 }
 
+% BTAC sources: input
 @article{full,
 	title = {Full entry, never queried, but field order changed},
 	author = {1789},
@@ -94,6 +101,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {full},
 }
 
+% BTAC sources: input
 @misc{marked,
 	title = {marked entry is not queried},
 	btacqueried = {2024-07-19},
@@ -101,12 +109,14 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	pages = {1--150},
 }
 
+% BTAC sources: input
 @article{markedbis,
 	title = {marked entry is not queried},
 	btacqueried = {not necessarily a data},
 	doi = {10.22222/123456789},
 }
 
+% BTAC sources: input, fake_lookup
 @misc{all_fields_for_misc,
 	title = {Test for filter-by-entrytype},
 	author = {My Guy},
@@ -124,6 +134,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	year = {2015},
 }
 
+% BTAC sources: input, fake_lookup
 @misc{opt_field_for_misc,
 	title = {Test for filter-by-entrytype},
 	author = {My Guy},
@@ -140,6 +151,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	year = {2015},
 }
 
+% BTAC sources: input, fake_lookup
 @misc{req_field_for_misc,
 	title = {Test for filter-by-entrytype},
 	BTACauthor = {Doe9, John},
@@ -155,6 +167,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	BTACvolume = {9},
 }
 
+% BTAC sources: input, fake_lookup
 @article{entry0,
 	title = {Title of entry 0},
 	BTACauthor = {Doe10, John},
@@ -170,6 +183,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	BTACvolume = {10},
 }
 
+% BTAC sources: input, fake_lookup
 @book{entry1,
 	title = {Title of entry 1},
 	BTACauthor = {Doe11, John},
@@ -185,6 +199,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	BTACvolume = {11},
 }
 
+% BTAC sources: input, fake_lookup
 @booklet{entry2,
 	title = {Title of entry 2},
 	BTACauthor = {Doe12, John},
@@ -200,6 +215,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	BTACvolume = {12},
 }
 
+% BTAC sources: input, fake_lookup
 @conference{entry3,
 	title = {Title of entry 3},
 	BTACauthor = {Doe13, John},
@@ -216,6 +232,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	BTACvolume = {13},
 }
 
+% BTAC sources: input, fake_lookup
 @inbook{entry4,
 	title = {Title of entry 4},
 	BTACauthor = {Doe14, John},
@@ -231,6 +248,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	BTACvolume = {14},
 }
 
+% BTAC sources: input, fake_lookup
 @incollection{entry5,
 	title = {Title of entry 5},
 	BTACauthor = {Doe15, John},
@@ -246,6 +264,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	BTACvolume = {15},
 }
 
+% BTAC sources: input, fake_lookup
 @manual{entry6,
 	title = {Title of entry 6},
 	BTACauthor = {Doe16, John},
@@ -261,6 +280,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	BTACvolume = {16},
 }
 
+% BTAC sources: input, fake_lookup
 @mastersthesis{entry7,
 	title = {Title of entry 7},
 	BTACauthor = {Doe17, John},
@@ -276,6 +296,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	BTACvolume = {17},
 }
 
+% BTAC sources: input, fake_lookup
 @misc{entry8,
 	title = {Title of entry 8},
 	BTACauthor = {Doe18, John},
@@ -291,6 +312,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	BTACvolume = {18},
 }
 
+% BTAC sources: input, fake_lookup
 @techreport{entry9,
 	title = {Title of entry 9},
 	BTACauthor = {Doe19, John},
@@ -306,6 +328,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	BTACvolume = {19},
 }
 
+% BTAC sources: input, fake_lookup
 @unpublished{entry10,
 	title = {Title of entry 10},
 	BTACauthor = {Doe20, John},
@@ -321,6 +344,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	BTACvolume = {20},
 }
 
+% BTAC sources: input, fake_lookup
 @inproceedings{entry11,
 	title = {Title of entry 11},
 	BTACauthor = {Doe21, John},
@@ -336,6 +360,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	BTACvolume = {21},
 }
 
+% BTAC sources: input, fake_lookup
 @phdthesis{entry12,
 	title = {Title of entry 12},
 	BTACauthor = {Doe22, John},
@@ -351,6 +376,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	BTACvolume = {22},
 }
 
+% BTAC sources: input, fake_lookup
 @misc{with_accents,
 	title = {Lots OF accents AnD Capitalization: éàêïæøçÉÀÊÏÆØÇ},
 	author = {Somebody},

--- a/tests/bibs/select-all.btac.bib.exp
+++ b/tests/bibs/select-all.btac.bib.exp
@@ -3,6 +3,7 @@
 
 @comment{Outside of entries, text is just a comment}
 
+% BTAC sources: input, fake_lookup
 @misc{entry_basic,
 	title = {My awesome article},
 	author = {Yours Truly},
@@ -11,6 +12,7 @@
 Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 }
 
+% BTAC sources: input, fake_lookup
 @article{entry_basic2,
 	title = {Something},
 	author = {Someone},
@@ -24,14 +26,17 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {2},
 }
 
+% BTAC sources: input
 @booklet{almost_empty,
 	note = {This entry shouldn't be queried, no useful data},
 }
 
+% BTAC sources: input
 @techreport{also_almost_empty,
 	foo = {bar: no standard field at all},
 }
 
+% BTAC sources: input, fake_lookup
 @article{doi,
 	title = {Generated title 5},
 	author = {Doe5, John},
@@ -44,6 +49,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {5},
 }
 
+% BTAC sources: input, fake_lookup
 @inproceedings{giberish,
 	title = {giberish},
 	author = {1789},
@@ -60,6 +66,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {6},
 }
 
+% BTAC sources: input
 @article{full,
 	title = {Full entry, never queried, but field order changed},
 	author = {1789},
@@ -78,6 +85,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {full},
 }
 
+% BTAC sources: input
 @misc{marked,
 	title = {marked entry is not queried},
 	btacqueried = {2024-07-19},
@@ -85,12 +93,14 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	pages = {1--150},
 }
 
+% BTAC sources: input
 @article{markedbis,
 	title = {marked entry is not queried},
 	btacqueried = {not necessarily a data},
 	doi = {10.22222/123456789},
 }
 
+% BTAC sources: input
 @misc{all_fields_for_misc,
 	title = {Test for filter-by-entrytype},
 	author = {My Guy},
@@ -101,6 +111,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	year = {2015},
 }
 
+% BTAC sources: input
 @misc{opt_field_for_misc,
 	title = {Test for filter-by-entrytype},
 	author = {My Guy},
@@ -110,6 +121,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	year = {2015},
 }
 
+% BTAC sources: input, fake_lookup
 @misc{req_field_for_misc,
 	title = {Test for filter-by-entrytype},
 	author = {Doe8, John},
@@ -119,6 +131,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 }
 
+% BTAC sources: input, fake_lookup
 @article{entry0,
 	title = {Title of entry 0},
 	author = {Doe9, John},
@@ -130,6 +143,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {9},
 }
 
+% BTAC sources: input, fake_lookup
 @book{entry1,
 	title = {Title of entry 1},
 	author = {Doe10, John},
@@ -140,6 +154,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {10},
 }
 
+% BTAC sources: input, fake_lookup
 @booklet{entry2,
 	title = {Title of entry 2},
 	author = {Doe11, John},
@@ -149,6 +164,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 }
 
+% BTAC sources: input, fake_lookup
 @conference{entry3,
 	title = {Title of entry 3},
 	author = {Doe12, John},
@@ -161,6 +177,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {12},
 }
 
+% BTAC sources: input, fake_lookup
 @inbook{entry4,
 	title = {Title of entry 4},
 	author = {Doe13, John},
@@ -172,6 +189,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {13},
 }
 
+% BTAC sources: input, fake_lookup
 @incollection{entry5,
 	title = {Title of entry 5},
 	author = {Doe14, John},
@@ -185,6 +203,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {14},
 }
 
+% BTAC sources: input, fake_lookup
 @manual{entry6,
 	title = {Title of entry 6},
 	author = {Doe15, John},
@@ -195,6 +214,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	organization = {organization 15},
 }
 
+% BTAC sources: input, fake_lookup
 @mastersthesis{entry7,
 	title = {Title of entry 7},
 	author = {Doe16, John},
@@ -203,6 +223,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 }
 
+% BTAC sources: input, fake_lookup
 @misc{entry8,
 	title = {Title of entry 8},
 	author = {Doe17, John},
@@ -212,6 +233,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 }
 
+% BTAC sources: input, fake_lookup
 @techreport{entry9,
 	title = {Title of entry 9},
 	author = {Doe18, John},
@@ -220,6 +242,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 }
 
+% BTAC sources: input, fake_lookup
 @unpublished{entry10,
 	title = {Title of entry 10},
 	author = {Doe19, John},
@@ -228,6 +251,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 }
 
+% BTAC sources: input, fake_lookup
 @inproceedings{entry11,
 	title = {Title of entry 11},
 	author = {Doe20, John},
@@ -241,6 +265,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {20},
 }
 
+% BTAC sources: input, fake_lookup
 @phdthesis{entry12,
 	title = {Title of entry 12},
 	author = {Doe21, John},
@@ -249,6 +274,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 }
 
+% BTAC sources: input, fake_lookup
 @misc{with_accents,
 	title = {Lots OF accents AnD Capitalization: éàêïæøçÉÀÊÏÆØÇ},
 	author = {Somebody},

--- a/tests/bibs/select-optional.btac.bib.exp
+++ b/tests/bibs/select-optional.btac.bib.exp
@@ -3,6 +3,7 @@
 
 @comment{Outside of entries, text is just a comment}
 
+% BTAC sources: input, fake_lookup
 @misc{entry_basic,
 	title = {My awesome article},
 	author = {Yours Truly},
@@ -11,6 +12,7 @@
 Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 }
 
+% BTAC sources: input, fake_lookup
 @article{entry_basic2,
 	title = {Something},
 	author = {Someone},
@@ -22,14 +24,17 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {2},
 }
 
+% BTAC sources: input
 @booklet{almost_empty,
 	note = {This entry shouldn't be queried, no useful data},
 }
 
+% BTAC sources: input
 @techreport{also_almost_empty,
 	foo = {bar: no standard field at all},
 }
 
+% BTAC sources: input, fake_lookup
 @article{doi,
 	title = {Generated title 5},
 	author = {Doe5, John},
@@ -42,6 +47,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {5},
 }
 
+% BTAC sources: input, fake_lookup
 @inproceedings{giberish,
 	title = {giberish},
 	author = {1789},
@@ -58,6 +64,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {6},
 }
 
+% BTAC sources: input
 @article{full,
 	title = {Full entry, never queried, but field order changed},
 	author = {1789},
@@ -76,6 +83,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {full},
 }
 
+% BTAC sources: input
 @misc{marked,
 	title = {marked entry is not queried},
 	btacqueried = {2024-07-19},
@@ -83,12 +91,14 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	pages = {1--150},
 }
 
+% BTAC sources: input
 @article{markedbis,
 	title = {marked entry is not queried},
 	btacqueried = {not necessarily a data},
 	doi = {10.22222/123456789},
 }
 
+% BTAC sources: input
 @misc{all_fields_for_misc,
 	title = {Test for filter-by-entrytype},
 	author = {My Guy},
@@ -99,6 +109,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	year = {2015},
 }
 
+% BTAC sources: input
 @misc{opt_field_for_misc,
 	title = {Test for filter-by-entrytype},
 	author = {My Guy},
@@ -108,6 +119,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	year = {2015},
 }
 
+% BTAC sources: input, fake_lookup
 @misc{req_field_for_misc,
 	title = {Test for filter-by-entrytype},
 	author = {Doe7, John},
@@ -116,6 +128,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 }
 
+% BTAC sources: input, fake_lookup
 @article{entry0,
 	title = {Title of entry 0},
 	author = {Doe8, John},
@@ -127,6 +140,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {8},
 }
 
+% BTAC sources: input, fake_lookup
 @book{entry1,
 	title = {Title of entry 1},
 	author = {Doe9, John},
@@ -137,6 +151,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {9},
 }
 
+% BTAC sources: input, fake_lookup
 @booklet{entry2,
 	title = {Title of entry 2},
 	author = {Doe10, John},
@@ -145,6 +160,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 }
 
+% BTAC sources: input, fake_lookup
 @conference{entry3,
 	title = {Title of entry 3},
 	author = {Doe11, John},
@@ -157,6 +173,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {11},
 }
 
+% BTAC sources: input, fake_lookup
 @inbook{entry4,
 	title = {Title of entry 4},
 	author = {Doe12, John},
@@ -168,6 +185,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {12},
 }
 
+% BTAC sources: input, fake_lookup
 @incollection{entry5,
 	title = {Title of entry 5},
 	author = {Doe13, John},
@@ -180,6 +198,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {13},
 }
 
+% BTAC sources: input, fake_lookup
 @manual{entry6,
 	title = {Title of entry 6},
 	author = {Doe14, John},
@@ -190,6 +209,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	organization = {organization 14},
 }
 
+% BTAC sources: input, fake_lookup
 @mastersthesis{entry7,
 	title = {Title of entry 7},
 	author = {Doe15, John},
@@ -198,6 +218,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 }
 
+% BTAC sources: input, fake_lookup
 @misc{entry8,
 	title = {Title of entry 8},
 	author = {Doe16, John},
@@ -206,6 +227,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 }
 
+% BTAC sources: input, fake_lookup
 @techreport{entry9,
 	title = {Title of entry 9},
 	author = {Doe17, John},
@@ -214,6 +236,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 }
 
+% BTAC sources: input, fake_lookup
 @unpublished{entry10,
 	title = {Title of entry 10},
 	author = {Doe18, John},
@@ -222,6 +245,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 }
 
+% BTAC sources: input, fake_lookup
 @inproceedings{entry11,
 	title = {Title of entry 11},
 	author = {Doe19, John},
@@ -234,6 +258,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {19},
 }
 
+% BTAC sources: input, fake_lookup
 @phdthesis{entry12,
 	title = {Title of entry 12},
 	author = {Doe20, John},
@@ -242,6 +267,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 }
 
+% BTAC sources: input, fake_lookup
 @misc{with_accents,
 	title = {Lots OF accents AnD Capitalization: éàêïæøçÉÀÊÏÆØÇ},
 	author = {Somebody},

--- a/tests/bibs/select-required.btac.bib.exp
+++ b/tests/bibs/select-required.btac.bib.exp
@@ -3,25 +3,30 @@
 
 @comment{Outside of entries, text is just a comment}
 
+% BTAC sources: input
 @misc{entry_basic,
 	title = {My awesome article},
 	author = {Yours Truly},
 }
 
+% BTAC sources: input, fake_lookup
 @article{entry_basic2,
 	title = {Something},
 	author = {Someone},
 	journal = {Generated Journal 1},
 }
 
+% BTAC sources: input
 @booklet{almost_empty,
 	note = {This entry shouldn't be queried, no useful data},
 }
 
+% BTAC sources: input
 @techreport{also_almost_empty,
 	foo = {bar: no standard field at all},
 }
 
+% BTAC sources: input, fake_lookup
 @article{doi,
 	title = {Generated title 4},
 	author = {Doe4, John},
@@ -29,6 +34,7 @@
 	journal = {Generated Journal 4},
 }
 
+% BTAC sources: input, fake_lookup
 @inproceedings{giberish,
 	title = {giberish},
 	author = {1789},
@@ -41,6 +47,7 @@
 	pages = {not a number},
 }
 
+% BTAC sources: input
 @article{full,
 	title = {Full entry, never queried, but field order changed},
 	author = {1789},
@@ -59,6 +66,7 @@
 	volume = {full},
 }
 
+% BTAC sources: input
 @misc{marked,
 	title = {marked entry is not queried},
 	btacqueried = {2024-07-19},
@@ -66,12 +74,14 @@
 	pages = {1--150},
 }
 
+% BTAC sources: input
 @article{markedbis,
 	title = {marked entry is not queried},
 	btacqueried = {not necessarily a data},
 	doi = {10.22222/123456789},
 }
 
+% BTAC sources: input
 @misc{all_fields_for_misc,
 	title = {Test for filter-by-entrytype},
 	author = {My Guy},
@@ -82,6 +92,7 @@
 	year = {2015},
 }
 
+% BTAC sources: input
 @misc{opt_field_for_misc,
 	title = {Test for filter-by-entrytype},
 	author = {My Guy},
@@ -91,61 +102,73 @@
 	year = {2015},
 }
 
+% BTAC sources: input
 @misc{req_field_for_misc,
 	title = {Test for filter-by-entrytype},
 }
 
+% BTAC sources: input, fake_lookup
 @article{entry0,
 	title = {Title of entry 0},
 	author = {Doe6, John},
 	journal = {Generated Journal 6},
 }
 
+% BTAC sources: input, fake_lookup
 @book{entry1,
 	title = {Title of entry 1},
 	author = {Doe7, John},
 }
 
+% BTAC sources: input
 @booklet{entry2,
 	title = {Title of entry 2},
 }
 
+% BTAC sources: input, fake_lookup
 @conference{entry3,
 	title = {Title of entry 3},
 	author = {Doe8, John},
 	booktitle = {Generated booktitle 8},
 }
 
+% BTAC sources: input, fake_lookup
 @inbook{entry4,
 	title = {Title of entry 4},
 	author = {Doe9, John},
 	pages = {1--9},
 }
 
+% BTAC sources: input, fake_lookup
 @incollection{entry5,
 	title = {Title of entry 5},
 	author = {Doe10, John},
 	booktitle = {Generated booktitle 10},
 }
 
+% BTAC sources: input
 @manual{entry6,
 	title = {Title of entry 6},
 }
 
+% BTAC sources: input, fake_lookup
 @mastersthesis{entry7,
 	title = {Title of entry 7},
 	author = {Doe11, John},
 }
 
+% BTAC sources: input
 @misc{entry8,
 	title = {Title of entry 8},
 }
 
+% BTAC sources: input, fake_lookup
 @techreport{entry9,
 	title = {Title of entry 9},
 	author = {Doe12, John},
 }
 
+% BTAC sources: input, fake_lookup
 @unpublished{entry10,
 	title = {Title of entry 10},
 	author = {Doe13, John},
@@ -153,17 +176,20 @@
 Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 }
 
+% BTAC sources: input, fake_lookup
 @inproceedings{entry11,
 	title = {Title of entry 11},
 	author = {Doe14, John},
 	booktitle = {Generated booktitle 14},
 }
 
+% BTAC sources: input, fake_lookup
 @phdthesis{entry12,
 	title = {Title of entry 12},
 	author = {Doe15, John},
 }
 
+% BTAC sources: input
 @misc{with_accents,
 	title = {Lots OF accents AnD Capitalization: éàêïæøçÉÀÊÏÆØÇ},
 	author = {Somebody},

--- a/tests/bibs/selection-ignore-mark.btac.bib.exp
+++ b/tests/bibs/selection-ignore-mark.btac.bib.exp
@@ -3,6 +3,7 @@
 
 @comment{Outside of entries, text is just a comment}
 
+% BTAC sources: input, fake_lookup
 @misc{entry_basic,
 	title = {My awesome article},
 	author = {Yours Truly},
@@ -18,19 +19,23 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {1},
 }
 
+% BTAC sources: input
 @article{entry_basic2,
 	title = {Something},
 	author = {Someone},
 }
 
+% BTAC sources: input
 @booklet{almost_empty,
 	note = {This entry shouldn't be queried, no useful data},
 }
 
+% BTAC sources: input
 @techreport{also_almost_empty,
 	foo = {bar: no standard field at all},
 }
 
+% BTAC sources: input, fake_lookup
 @article{doi,
 	title = {Generated title 3},
 	author = {Doe3, John},
@@ -47,6 +52,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {3},
 }
 
+% BTAC sources: input
 @inproceedings{giberish,
 	title = {giberish},
 	author = {1789},
@@ -58,6 +64,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	pages = {not a number},
 }
 
+% BTAC sources: input
 @article{full,
 	title = {Full entry, never queried, but field order changed},
 	author = {1789},
@@ -76,6 +83,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {full},
 }
 
+% BTAC sources: input, fake_lookup
 @misc{marked,
 	title = {marked entry is not queried},
 	author = {Doe4, John},
@@ -92,12 +100,14 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {4},
 }
 
+% BTAC sources: input
 @article{markedbis,
 	title = {marked entry is not queried},
 	btacqueried = {not necessarily a data},
 	doi = {10.22222/123456789},
 }
 
+% BTAC sources: input
 @misc{all_fields_for_misc,
 	title = {Test for filter-by-entrytype},
 	author = {My Guy},
@@ -108,6 +118,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	year = {2015},
 }
 
+% BTAC sources: input, fake_lookup
 @misc{opt_field_for_misc,
 	title = {Test for filter-by-entrytype},
 	author = {My Guy},
@@ -124,6 +135,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	year = {2015},
 }
 
+% BTAC sources: input, fake_lookup
 @misc{req_field_for_misc,
 	title = {Test for filter-by-entrytype},
 	author = {Doe6, John},
@@ -139,6 +151,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {6},
 }
 
+% BTAC sources: input, fake_lookup
 @article{entry0,
 	title = {Title of entry 0},
 	author = {Doe7, John},
@@ -154,10 +167,12 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {7},
 }
 
+% BTAC sources: input
 @book{entry1,
 	title = {Title of entry 1},
 }
 
+% BTAC sources: input, fake_lookup
 @booklet{entry2,
 	title = {Title of entry 2},
 	author = {Doe8, John},
@@ -173,10 +188,12 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {8},
 }
 
+% BTAC sources: input
 @conference{entry3,
 	title = {Title of entry 3},
 }
 
+% BTAC sources: input, fake_lookup
 @inbook{entry4,
 	title = {Title of entry 4},
 	author = {Doe9, John},
@@ -192,10 +209,12 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {9},
 }
 
+% BTAC sources: input
 @incollection{entry5,
 	title = {Title of entry 5},
 }
 
+% BTAC sources: input, fake_lookup
 @manual{entry6,
 	title = {Title of entry 6},
 	author = {Doe10, John},
@@ -211,10 +230,12 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {10},
 }
 
+% BTAC sources: input
 @mastersthesis{entry7,
 	title = {Title of entry 7},
 }
 
+% BTAC sources: input, fake_lookup
 @misc{entry8,
 	title = {Title of entry 8},
 	author = {Doe11, John},
@@ -230,10 +251,12 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {11},
 }
 
+% BTAC sources: input
 @techreport{entry9,
 	title = {Title of entry 9},
 }
 
+% BTAC sources: input, fake_lookup
 @unpublished{entry10,
 	title = {Title of entry 10},
 	author = {Doe12, John},
@@ -249,10 +272,12 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {12},
 }
 
+% BTAC sources: input
 @inproceedings{entry11,
 	title = {Title of entry 11},
 }
 
+% BTAC sources: input, fake_lookup
 @phdthesis{entry12,
 	title = {Title of entry 12},
 	author = {Doe13, John},
@@ -269,6 +294,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {13},
 }
 
+% BTAC sources: input, fake_lookup
 @misc{with_accents,
 	title = {Lots OF accents AnD Capitalization: éàêïæøçÉÀÊÏÆØÇ},
 	author = {Somebody},

--- a/tests/bibs/selection.btac.bib.exp
+++ b/tests/bibs/selection.btac.bib.exp
@@ -3,6 +3,7 @@
 
 @comment{Outside of entries, text is just a comment}
 
+% BTAC sources: input, fake_lookup
 @misc{entry_basic,
 	title = {My awesome article},
 	author = {Yours Truly},
@@ -18,19 +19,23 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {1},
 }
 
+% BTAC sources: input
 @article{entry_basic2,
 	title = {Something},
 	author = {Someone},
 }
 
+% BTAC sources: input
 @booklet{almost_empty,
 	note = {This entry shouldn't be queried, no useful data},
 }
 
+% BTAC sources: input
 @techreport{also_almost_empty,
 	foo = {bar: no standard field at all},
 }
 
+% BTAC sources: input, fake_lookup
 @article{doi,
 	title = {Generated title 3},
 	author = {Doe3, John},
@@ -47,6 +52,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {3},
 }
 
+% BTAC sources: input
 @inproceedings{giberish,
 	title = {giberish},
 	author = {1789},
@@ -58,6 +64,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	pages = {not a number},
 }
 
+% BTAC sources: input
 @article{full,
 	title = {Full entry, never queried, but field order changed},
 	author = {1789},
@@ -76,6 +83,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {full},
 }
 
+% BTAC sources: input
 @misc{marked,
 	title = {marked entry is not queried},
 	btacqueried = {2024-07-19},
@@ -83,12 +91,14 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	pages = {1--150},
 }
 
+% BTAC sources: input
 @article{markedbis,
 	title = {marked entry is not queried},
 	btacqueried = {not necessarily a data},
 	doi = {10.22222/123456789},
 }
 
+% BTAC sources: input
 @misc{all_fields_for_misc,
 	title = {Test for filter-by-entrytype},
 	author = {My Guy},
@@ -99,6 +109,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	year = {2015},
 }
 
+% BTAC sources: input, fake_lookup
 @misc{opt_field_for_misc,
 	title = {Test for filter-by-entrytype},
 	author = {My Guy},
@@ -115,6 +126,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	year = {2015},
 }
 
+% BTAC sources: input, fake_lookup
 @misc{req_field_for_misc,
 	title = {Test for filter-by-entrytype},
 	author = {Doe5, John},
@@ -130,6 +142,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {5},
 }
 
+% BTAC sources: input, fake_lookup
 @article{entry0,
 	title = {Title of entry 0},
 	author = {Doe6, John},
@@ -145,10 +158,12 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {6},
 }
 
+% BTAC sources: input
 @book{entry1,
 	title = {Title of entry 1},
 }
 
+% BTAC sources: input, fake_lookup
 @booklet{entry2,
 	title = {Title of entry 2},
 	author = {Doe7, John},
@@ -164,10 +179,12 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {7},
 }
 
+% BTAC sources: input
 @conference{entry3,
 	title = {Title of entry 3},
 }
 
+% BTAC sources: input, fake_lookup
 @inbook{entry4,
 	title = {Title of entry 4},
 	author = {Doe8, John},
@@ -183,10 +200,12 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {8},
 }
 
+% BTAC sources: input
 @incollection{entry5,
 	title = {Title of entry 5},
 }
 
+% BTAC sources: input, fake_lookup
 @manual{entry6,
 	title = {Title of entry 6},
 	author = {Doe9, John},
@@ -202,10 +221,12 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {9},
 }
 
+% BTAC sources: input
 @mastersthesis{entry7,
 	title = {Title of entry 7},
 }
 
+% BTAC sources: input, fake_lookup
 @misc{entry8,
 	title = {Title of entry 8},
 	author = {Doe10, John},
@@ -221,10 +242,12 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {10},
 }
 
+% BTAC sources: input
 @techreport{entry9,
 	title = {Title of entry 9},
 }
 
+% BTAC sources: input, fake_lookup
 @unpublished{entry10,
 	title = {Title of entry 10},
 	author = {Doe11, John},
@@ -240,10 +263,12 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {11},
 }
 
+% BTAC sources: input
 @inproceedings{entry11,
 	title = {Title of entry 11},
 }
 
+% BTAC sources: input, fake_lookup
 @phdthesis{entry12,
 	title = {Title of entry 12},
 	author = {Doe12, John},
@@ -259,6 +284,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {12},
 }
 
+% BTAC sources: input, fake_lookup
 @misc{with_accents,
 	title = {Lots OF accents AnD Capitalization: éàêïæøçÉÀÊÏÆØÇ},
 	author = {Somebody},

--- a/tests/bibs/start-from.btac.bib.exp
+++ b/tests/bibs/start-from.btac.bib.exp
@@ -3,28 +3,34 @@
 
 @comment{Outside of entries, text is just a comment}
 
+% BTAC sources: input
 @misc{entry_basic,
 	title = {My awesome article},
 	author = {Yours Truly},
 }
 
+% BTAC sources: input
 @article{entry_basic2,
 	title = {Something},
 	author = {Someone},
 }
 
+% BTAC sources: input
 @booklet{almost_empty,
 	note = {This entry shouldn't be queried, no useful data},
 }
 
+% BTAC sources: input
 @techreport{also_almost_empty,
 	foo = {bar: no standard field at all},
 }
 
+% BTAC sources: input
 @article{doi,
 	doi = {10.5432/hello},
 }
 
+% BTAC sources: input
 @inproceedings{giberish,
 	title = {giberish},
 	author = {1789},
@@ -36,6 +42,7 @@
 	pages = {not a number},
 }
 
+% BTAC sources: input
 @article{full,
 	title = {Full entry, never queried, but field order changed},
 	author = {1789},
@@ -54,6 +61,7 @@
 	volume = {full},
 }
 
+% BTAC sources: input
 @misc{marked,
 	title = {marked entry is not queried},
 	btacqueried = {2024-07-19},
@@ -61,12 +69,14 @@
 	pages = {1--150},
 }
 
+% BTAC sources: input
 @article{markedbis,
 	title = {marked entry is not queried},
 	btacqueried = {not necessarily a data},
 	doi = {10.22222/123456789},
 }
 
+% BTAC sources: input
 @misc{all_fields_for_misc,
 	title = {Test for filter-by-entrytype},
 	author = {My Guy},
@@ -77,6 +87,7 @@
 	year = {2015},
 }
 
+% BTAC sources: input
 @misc{opt_field_for_misc,
 	title = {Test for filter-by-entrytype},
 	author = {My Guy},
@@ -86,10 +97,12 @@
 	year = {2015},
 }
 
+% BTAC sources: input
 @misc{req_field_for_misc,
 	title = {Test for filter-by-entrytype},
 }
 
+% BTAC sources: input, fake_lookup
 @article{entry0,
 	title = {Title of entry 0},
 	author = {Doe1, John},
@@ -105,6 +118,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {1},
 }
 
+% BTAC sources: input, fake_lookup
 @book{entry1,
 	title = {Title of entry 1},
 	author = {Doe2, John},
@@ -121,6 +135,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {2},
 }
 
+% BTAC sources: input, fake_lookup
 @booklet{entry2,
 	title = {Title of entry 2},
 	author = {Doe3, John},
@@ -136,6 +151,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {3},
 }
 
+% BTAC sources: input, fake_lookup
 @conference{entry3,
 	title = {Title of entry 3},
 	author = {Doe4, John},
@@ -151,6 +167,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {4},
 }
 
+% BTAC sources: input, fake_lookup
 @inbook{entry4,
 	title = {Title of entry 4},
 	author = {Doe5, John},
@@ -166,6 +183,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {5},
 }
 
+% BTAC sources: input, fake_lookup
 @incollection{entry5,
 	title = {Title of entry 5},
 	author = {Doe6, John},
@@ -181,6 +199,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {6},
 }
 
+% BTAC sources: input, fake_lookup
 @manual{entry6,
 	title = {Title of entry 6},
 	author = {Doe7, John},
@@ -196,6 +215,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {7},
 }
 
+% BTAC sources: input, fake_lookup
 @mastersthesis{entry7,
 	title = {Title of entry 7},
 	author = {Doe8, John},
@@ -211,6 +231,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {8},
 }
 
+% BTAC sources: input, fake_lookup
 @misc{entry8,
 	title = {Title of entry 8},
 	author = {Doe9, John},
@@ -226,6 +247,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {9},
 }
 
+% BTAC sources: input, fake_lookup
 @techreport{entry9,
 	title = {Title of entry 9},
 	author = {Doe10, John},
@@ -241,6 +263,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {10},
 }
 
+% BTAC sources: input, fake_lookup
 @unpublished{entry10,
 	title = {Title of entry 10},
 	author = {Doe11, John},
@@ -256,6 +279,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {11},
 }
 
+% BTAC sources: input, fake_lookup
 @inproceedings{entry11,
 	title = {Title of entry 11},
 	author = {Doe12, John},
@@ -271,6 +295,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {12},
 }
 
+% BTAC sources: input, fake_lookup
 @phdthesis{entry12,
 	title = {Title of entry 12},
 	author = {Doe13, John},
@@ -287,6 +312,7 @@ Newline UppERcaSE AND accents: éàêïæøçÉÀÊÏÆØÇ},
 	volume = {13},
 }
 
+% BTAC sources: input, fake_lookup
 @misc{with_accents,
 	title = {Lots OF accents AnD Capitalization: éàêïæøçÉÀÊÏÆØÇ},
 	author = {Somebody},


### PR DESCRIPTION
## Summary
- add a custom BibTeX writer that can prepend per-entry source comments
- track lookup sources for each entry during autocompletion and pass them to the writer
- update expected fixture BibTeX files to include `% BTAC sources: …` comments before each entry

## Testing
- `python -m pytest` *(fails: DOI and URL integration tests require external network access in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c92a91453883259119a8d15ddf4a6e