### PR TITLE
fix: enforce author mismatch no-match

### DIFF
--- a/bibtexautocomplete/bibtex/entry.py
+++ b/bibtexautocomplete/bibtex/entry.py
@@ -236,10 +236,13 @@ class BibtexEntry:
             total += FIELD_MULTIPLIERS["doi"][0] * doi_match
         # Match authors before deciding on early exit so author agreement
         # can compensate for partial title mismatches
-        author_match = self.get_field("author").matches(other.get_field("author"))
-        if author_match is not None:
-            if author_match <= FIELD_NO_MATCH:
+        author_field = self.get_field("author")
+        other_author_field = other.get_field("author")
+        author_match = author_field.matches(other_author_field)
+        if author_field.value is not None and other_author_field.value is not None:
+            if author_match is None or author_match <= FIELD_NO_MATCH:
                 return ENTRY_NO_MATCH
+        if author_match is not None:
             total += FIELD_MULTIPLIERS["author"][0] * author_match
         # If neither title, DOI nor author match, we can't id the entry with any certainty
         if total <= ENTRY_NO_MATCH:


### PR DESCRIPTION
## Summary
- integrate zbMATH Open API lookup
- register new lookup in lookup registry
- test zbMATH author parsing
- add make target to run individual tests
- cover zbMATH lookup for several real entries
- quote titles, recover DOI from links, and relax matching on author-only hits
- ensure author mismatches between populated entries still force ENTRY_NO_MATCH

## Testing
- `make test_zbmath`


------
https://chatgpt.com/codex/tasks/task_e_68c94d4006ac832587cf0581181a50d8