### PR TITLE
Add replace-entry option prioritising first lookup

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,10 +259,17 @@ regularly.
 - `-q --only-query <site>` or `-Q --dont-query <site>`
 
   Restrict which websites to query from. `<site>` must be one of: `openalex`,
-  `crossref`, `arxiv`, `s2`, `unpaywall`, `dblp`, `researchr`, `hep`. These arguments
+  `crossref`, `arxiv`, `s2`, `unpaywall`, `dblp`, `researchr`, `hep`, `zbmath`. These arguments
   can be used multiple times, for example to only query Crossref and DBLP use
   `-q crossref -q dblp` or
   `-Q openalex -Q researchr -Q unpaywall -Q arxiv -Q s2 -Q hep`
+
+- `-R --replace-entry`
+
+  When used together with `-q/--only-query`, clear the existing BibTeX entry
+  (preserving its key and entry type) and repopulate it with data from the first
+  lookup that returns a result. Additional lookups are ignored for data
+  population, so order the `-q` flags to match your priority.
 
 - `-e --only-entry <id>` or `-E --exclude-entry <id>`
 

--- a/bibtexautocomplete/core/main.py
+++ b/bibtexautocomplete/core/main.py
@@ -147,6 +147,14 @@ def main(argv: Optional[List[str]] = None) -> int:
             # Print set without leading and ending brace
             logger.warn("Duplicate '-q' arguments ignored: {set}", set=str(dups)[1:-1])
         lookups = list_sort_using(lookups, args.only_query, lambda x: x.name)
+    if args.replace_entry and args.only_query == []:
+        try:
+            parser.error(
+                "{StBold}Invalid option combination:\n{Reset}"
+                "  {FgYellow}-R/--replace-entry{Reset} requires at least one {FgYellow}-q/--only-query{Reset} lookup"
+            )
+        except ValueError:
+            return ErrorCodes.CLI_ERROR
 
     fields = OnlyExclude[FieldType].from_nonempty(args.only_complete, args.dont_complete)
     if args.only_complete != [] and args.dont_complete != []:
@@ -217,6 +225,7 @@ def main(argv: Optional[List[str]] = None) -> int:
             no_trailing_comma=args.no_trailing_comma,
             indent=args.indent,
             verbose=args.verbose,
+            replace_entry=args.replace_entry,
         )
         completer.load_file(args.input)
         completer.print_filters()

--- a/bibtexautocomplete/core/parser.py
+++ b/bibtexautocomplete/core/parser.py
@@ -135,6 +135,7 @@ def make_parser() -> MyParser:
 
     parser.add_argument("--dont-query", "-Q", action="append", default=[], choices=LOOKUP_NAMES)
     parser.add_argument("--only-query", "-q", action="append", default=[], choices=LOOKUP_NAMES)
+    parser.add_argument("--replace-entry", "-R", action="store_true")
     parser.add_argument("--dont-complete", "-C", action="append", default=[], choices=FIELD_NAMES)
     parser.add_argument("--only-complete", "-c", action="append", default=[], choices=FIELD_NAMES)
     parser.add_argument("--dont-overwrite", "-W", action="append", default=[], choices=FIELD_NAMES)

--- a/tests/test_replace_entry.py
+++ b/tests/test_replace_entry.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Iterator, List
+
+import pytest
+
+from bibtexautocomplete.bibtex.constants import FieldNamesSet
+from bibtexautocomplete.bibtex.entry import BibtexEntry
+from bibtexautocomplete.core import apis, parser
+from bibtexautocomplete.core.main import ErrorCodes, main
+from bibtexautocomplete.lookups.abstract_entry_lookup import AbstractEntryLookup
+
+
+class FakeZbMathLookup(AbstractEntryLookup):
+    """Lookup that always returns ZbMath-flavoured data."""
+
+    name = "zbmath"
+    fields = FieldNamesSet
+
+    def query(self) -> BibtexEntry:
+        entry = BibtexEntry(self.name, self.entry.id)
+        entry.title.set("ZbMath Title")
+        entry.journal.set("Zb Journal")
+        return entry
+
+
+class FakeCrossrefLookup(AbstractEntryLookup):
+    """Lookup that returns data distinct from ZbMath for prioritisation tests."""
+
+    name = "crossref"
+    fields = FieldNamesSet
+
+    def query(self) -> BibtexEntry:
+        entry = BibtexEntry(self.name, self.entry.id)
+        entry.title.set("Crossref Title")
+        entry.note.set("Crossref Note")
+        return entry
+
+
+@pytest.fixture
+def fake_lookups() -> Iterator[None]:
+    """Temporarily replace configured lookups with deterministic fakes."""
+
+    original_lookups: List[type[AbstractEntryLookup]] = list(apis.LOOKUPS)
+    original_lookup_names = list(apis.LOOKUP_NAMES)
+
+    fake_lookups_list: List[type[AbstractEntryLookup]] = [FakeZbMathLookup, FakeCrossrefLookup]
+    new_lookup_names = [cls.name for cls in fake_lookups_list]
+
+    apis.LOOKUPS[:] = fake_lookups_list
+    apis.LOOKUP_NAMES[:] = new_lookup_names
+    parser.LOOKUP_NAMES[:] = new_lookup_names
+
+    try:
+        yield
+    finally:
+        apis.LOOKUPS[:] = original_lookups
+        apis.LOOKUP_NAMES[:] = original_lookup_names
+        parser.LOOKUP_NAMES[:] = original_lookup_names
+
+
+def test_replace_entry_prefers_first_lookup(tmp_path: Path, fake_lookups: None) -> None:
+    input_path = tmp_path / "input.bib"
+    input_path.write_text(
+        "@article{replaceKey,\n"
+        "  title = {Original Title},\n"
+        "  note = {Original Note}\n"
+        "}\n",
+        encoding="utf-8",
+    )
+    output_path = tmp_path / "output.bib"
+
+    exit_code = main([
+        "-q",
+        "zbmath",
+        "-q",
+        "crossref",
+        "-R",
+        "-o",
+        str(output_path),
+        str(input_path),
+    ])
+
+    assert exit_code == ErrorCodes.SUCCESS
+
+    contents = output_path.read_text(encoding="utf-8")
+    assert "@article{replaceKey" in contents
+    assert "ZbMath Title" in contents
+    assert "Zb Journal" in contents
+    assert "Crossref Title" not in contents
+    assert "Crossref Note" not in contents
+    assert "Original Note" not in contents
+
+
+def test_replace_entry_requires_only_query(tmp_path: Path, fake_lookups: None) -> None:
+    input_path = tmp_path / "input.bib"
+    input_path.write_text("@article{replaceKey,}\n", encoding="utf-8")
+    output_path = tmp_path / "output.bib"
+
+    exit_code = main(["-R", "-o", str(output_path), str(input_path)])
+
+    assert exit_code == ErrorCodes.CLI_ERROR
+    assert not output_path.exists()


### PR DESCRIPTION
## Summary
- add a `--replace-entry`/`-R` flag to the CLI, document it, and validate it must be paired with `-q/--only-query`
- plumb the option into `BibtexAutocomplete` so the first successful lookup fully replaces an entry while keeping its key
- add regression tests exercising the new behaviour with deterministic fake lookups

## Testing
- pytest *(fails for DOI/URL network checks in tests/test_9_APIs.py due to lack of external access)*

------
https://chatgpt.com/codex/tasks/task_e_68c9584ec1c0832599680fb97d8c0ce7