### PR TITLE
Add replace-entry option prioritising first lookup

### DIFF
--- a/bibtexautocomplete/core/autocomplete.py
+++ b/bibtexautocomplete/core/autocomplete.py
@@ -308,7 +308,10 @@ class BibtexAutocomplete(Iterable[EntryType]):
         for x in entries:
             bib = BibtexEntry.from_entry(INPUT_SOURCE, x)
             bib_entries.append(bib)
-            to_complete.append(self.get_fields_to_complete(x))
+            fields_for_entry = self.get_fields_to_complete(x)
+            if self.replace_entry and not fields_for_entry:
+                fields_for_entry = self.get_fields_to_complete_by_entrytype(x)
+            to_complete.append(fields_for_entry)
 
         # Create all threads
         condition = Condition()


### PR DESCRIPTION
## Summary
- add a `--replace-entry`/`-R` flag to the CLI, document it, and validate it must be paired with `-q/--only-query`
- plumb the option into `BibtexAutocomplete` so the first successful lookup fully replaces an entry while keeping its key
- add regression tests exercising the new behaviour with deterministic fake lookups
- ensure replace-entry triggers lookups for fully populated entries and cover the regression with a dedicated test

## Testing
- PYTHONPATH=. pytest tests/test_replace_entry.py

------
https://chatgpt.com/codex/tasks/task_e_68c96dc87e0c83259c5b47b7020e328c