### PR TITLE
Prefer zbMATH short journal titles

### DIFF
--- a/bibtexautocomplete/APIs/zbmath.py
+++ b/bibtexautocomplete/APIs/zbmath.py
@@ -120,7 +120,10 @@ class ZbMathLookup(JSON_Lookup):
         series = next(source["series"].iter_list(), None)
 
         if doc_type == "j" and series is not None:
-            values.journal.set(series["title"].to_str())
+            journal_title = series["short_title"].to_str()
+            if journal_title is None:
+                journal_title = series["title"].to_str()
+            values.journal.set(journal_title)
             values.volume.set(series["volume"].to_str())
             values.number.set(series["issue"].to_str())
             for issn in series["issn"].iter_list():

--- a/tests/test_zbmath.py
+++ b/tests/test_zbmath.py
@@ -63,6 +63,54 @@ def test_get_value_falls_back_to_query_doi() -> None:
     assert values.doi.to_str() == "10.5678/def"
 
 
+def _make_series(short: Optional[str], title: Optional[str]) -> Dict[str, object]:
+    return {
+        "acronym": None,
+        "issn": [],
+        "issue": None,
+        "issue_id": None,
+        "parallel_title": None,
+        "part": None,
+        "publisher": None,
+        "series_id": None,
+        "short_title": short,
+        "title": title,
+        "volume": None,
+        "year": None,
+    }
+
+
+def _make_result(series: Dict[str, object]) -> SafeJSON:
+    return SafeJSON(
+        {
+            "contributors": {"authors": []},
+            "document_type": {"code": "j"},
+            "doi": None,
+            "links": [],
+            "source": {"book": [], "pages": None, "series": [series]},
+            "title": {"title": "foo"},
+            "zbmath_url": "u",
+            "year": "2000",
+        }
+    )
+
+
+def test_get_value_prefers_short_title_for_journal() -> None:
+    bib = BibtexEntry("test", "id")
+    lookup = ZbMathLookup(bib)
+    data = _make_result(_make_series("Abbrev.", "Full Title"))
+    values = lookup.get_value(data)
+    assert values.journal.to_str() == "Abbrev."
+
+
+def test_get_value_uses_full_title_when_short_missing() -> None:
+    bib = BibtexEntry("test", "id")
+    lookup = ZbMathLookup(bib)
+    data = _make_result(_make_series(None, "Full Title"))
+    values = lookup.get_value(data)
+    assert values.journal.to_str() == "Full Title"
+
+
 def test_matches_author_allows_partial_title() -> None:
     a = BibtexEntry.from_entry(
         "test",


### PR DESCRIPTION
## Summary
- prefer the zbMATH `short_title` when filling the BibTeX journal field, falling back to the full title when needed
- add unit tests covering the new journal title handling logic

## Testing
- `PYTHONPATH=. pytest tests/test_zbmath.py::test_get_value_prefers_short_title_for_journal tests/test_zbmath.py::test_get_value_uses_full_title_when_short_missing`


------
https://chatgpt.com/codex/tasks/task_e_68c982dabcd48325873fd562f8444154